### PR TITLE
Set entity 

### DIFF
--- a/src/main/java/com/pickteam/PickTeamApplication.java
+++ b/src/main/java/com/pickteam/PickTeamApplication.java
@@ -1,4 +1,4 @@
-package mvc.pickteam;
+package com.pickteam;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/com/pickteam/domain/board/Board.java
+++ b/src/main/java/com/pickteam/domain/board/Board.java
@@ -1,0 +1,43 @@
+package com.pickteam.domain.board;
+
+import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.BaseTimeEntity;
+import com.pickteam.domain.team.Team;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Board extends BaseSoftDeleteByAnnotation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    private Team team;
+
+    // 하나의 게시판에는 다수의 게시물이 붙는다. 이를 관리하기 위해 OneToMany로 설정한다.
+    // 연관된 게시물 정보는 게시물이 hard-delete처리될 때, 같이 제거될 수 있도록 cascade 설정을 해준다.
+    // 연관관계가 끊어진 객체를 자동으로 날려주도록 orphanRemoval을 붙여준다.
+    @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Post> postList = new ArrayList<>();
+
+    // Soft-Delete 시, @SoftDelete 어노테이션은 자식객체에게 soft-delete를 전파해주지 않는다.
+    // Soft-Delete 동작 전파를 위해 OnSoftDelete를 오버라이드 (검증 필요함)
+
+    @Override
+    public void onSoftDelete() {
+        super.onSoftDelete();
+        postList.forEach(BaseSoftDeleteByAnnotation::markDeleted);
+
+    }
+
+}

--- a/src/main/java/com/pickteam/domain/board/Board.java
+++ b/src/main/java/com/pickteam/domain/board/Board.java
@@ -25,19 +25,10 @@ public class Board extends BaseSoftDeleteByAnnotation {
     private Team team;
 
     // 하나의 게시판에는 다수의 게시물이 붙는다. 이를 관리하기 위해 OneToMany로 설정한다.
-    // 연관된 게시물 정보는 게시물이 hard-delete처리될 때, 같이 제거될 수 있도록 cascade 설정을 해준다.
-    // 연관관계가 끊어진 객체를 자동으로 날려주도록 orphanRemoval을 붙여준다.
-    @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    // @SoftDelete annotation이 자식 엔티티에 대한 soft-delete를 불완전하게 지원한다. 따라서 cascade 설정은 하지 않는다.
+    // 연관 엔티티에 대한 soft-delete는 필요할 경우 repository 레이어나 service 레이어에서 순서를 정해 호출하는 별도 메소드를 정의한다
+    @OneToMany(mappedBy = "board")
     private List<Post> postList = new ArrayList<>();
 
-    // Soft-Delete 시, @SoftDelete 어노테이션은 자식객체에게 soft-delete를 전파해주지 않는다.
-    // Soft-Delete 동작 전파를 위해 OnSoftDelete를 오버라이드 (검증 필요함)
-
-    @Override
-    public void onSoftDelete() {
-        super.onSoftDelete();
-        postList.forEach(BaseSoftDeleteByAnnotation::markDeleted);
-
-    }
 
 }

--- a/src/main/java/com/pickteam/domain/board/Comment.java
+++ b/src/main/java/com/pickteam/domain/board/Comment.java
@@ -1,0 +1,29 @@
+package com.pickteam.domain.board;
+
+import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
+import com.pickteam.domain.user.Account;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Comment extends BaseSoftDeleteByAnnotation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Lob
+    private String content;
+
+    @ManyToOne(optional = false)
+    private Account account;
+
+    @ManyToOne(optional = false)
+    private Post post;
+}

--- a/src/main/java/com/pickteam/domain/board/Post.java
+++ b/src/main/java/com/pickteam/domain/board/Post.java
@@ -1,6 +1,7 @@
 package com.pickteam.domain.board;
 
 import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.user.Account;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -25,7 +26,10 @@ public class Post extends BaseSoftDeleteByAnnotation {
 
     private String title;
 
-    private String author;
+    //작성자 id
+    @ManyToOne(optional=false)
+    private Account account;
+
 
     @Lob
     private String content;

--- a/src/main/java/com/pickteam/domain/board/Post.java
+++ b/src/main/java/com/pickteam/domain/board/Post.java
@@ -38,22 +38,12 @@ public class Post extends BaseSoftDeleteByAnnotation {
     private Board board;
 
     // 하나의 게시물에는 다수의 첨부파일, 댓글 등이 붙을 수 있다. 이를 관리하기 위해 OneToMany로 설정한다.
-    // 연관된 첨부파일 정보는 게시물이 hard-delete처리될 때, 같이 제거될 수 있도록 cascade 설정을 해준다.
-    // 연관관계가 끊어진 객체를 자동으로 날려주도록 orphanRemoval을 붙여준다.
-    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE, orphanRemoval = true)
-    private List<PostAttach> attachments = new ArrayList<>();
+    // cascade 설정은 하지 않는다.
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "post")
+    private List<PostAttach> attachments = new ArrayList<>();
+    @OneToMany(mappedBy = "post")
     private List<Comment> comments = new ArrayList<>();
 
-    // Soft-Delete 시, @SoftDelete 어노테이션은 자식객체에게 soft-delete를 전파해주지 않는다.
-    // Soft-Delete 동작 전파를 위해 OnSoftDelete를 오버라이드 (검증 필요함)
-
-    @Override
-    public void onSoftDelete() {
-        super.onSoftDelete();
-        comments.forEach(BaseSoftDeleteByAnnotation::markDeleted);
-        attachments.forEach(BaseSoftDeleteByAnnotation::markDeleted);
-    }
 
 }

--- a/src/main/java/com/pickteam/domain/board/Post.java
+++ b/src/main/java/com/pickteam/domain/board/Post.java
@@ -1,0 +1,55 @@
+package com.pickteam.domain.board;
+
+import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Post extends BaseSoftDeleteByAnnotation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Integer postNo;
+    //DB의 기능을 사용하지 않고 Service단에서 board_id가 같은 마지막 포스트 번호를 쿼리해 수동 관리한다. (annotation 없음)
+
+    private String title;
+
+    private String author;
+
+    @Lob
+    private String content;
+
+    @ManyToOne(optional = false)
+    private Board board;
+
+    // 하나의 게시물에는 다수의 첨부파일, 댓글 등이 붙을 수 있다. 이를 관리하기 위해 OneToMany로 설정한다.
+    // 연관된 첨부파일 정보는 게시물이 hard-delete처리될 때, 같이 제거될 수 있도록 cascade 설정을 해준다.
+    // 연관관계가 끊어진 객체를 자동으로 날려주도록 orphanRemoval을 붙여준다.
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<PostAttach> attachments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
+
+    // Soft-Delete 시, @SoftDelete 어노테이션은 자식객체에게 soft-delete를 전파해주지 않는다.
+    // Soft-Delete 동작 전파를 위해 OnSoftDelete를 오버라이드 (검증 필요함)
+
+    @Override
+    public void onSoftDelete() {
+        super.onSoftDelete();
+        comments.forEach(BaseSoftDeleteByAnnotation::markDeleted);
+        attachments.forEach(BaseSoftDeleteByAnnotation::markDeleted);
+    }
+
+}

--- a/src/main/java/com/pickteam/domain/board/PostAttach.java
+++ b/src/main/java/com/pickteam/domain/board/PostAttach.java
@@ -1,0 +1,30 @@
+package com.pickteam.domain.board;
+
+import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.FileInfo;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostAttach extends BaseSoftDeleteByAnnotation {
+
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    // 첨부파일은 파일 정보와 1:1 매핑된다.
+    @OneToOne(cascade = CascadeType.REMOVE, orphanRemoval = true, optional = false)
+    @JoinColumn(name = "file_info_id", nullable = false)
+    private FileInfo fileInfo;
+
+}

--- a/src/main/java/com/pickteam/domain/board/PostAttach.java
+++ b/src/main/java/com/pickteam/domain/board/PostAttach.java
@@ -13,7 +13,6 @@ import lombok.*;
 @Builder
 public class PostAttach extends BaseSoftDeleteByAnnotation {
 
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -23,7 +22,7 @@ public class PostAttach extends BaseSoftDeleteByAnnotation {
     private Post post;
 
     // 첨부파일은 파일 정보와 1:1 매핑된다.
-    @OneToOne(cascade = CascadeType.REMOVE, orphanRemoval = true, optional = false)
+    @OneToOne(optional = false)
     @JoinColumn(name = "file_info_id", nullable = false)
     private FileInfo fileInfo;
 

--- a/src/main/java/com/pickteam/domain/chat/ChatAttach.java
+++ b/src/main/java/com/pickteam/domain/chat/ChatAttach.java
@@ -21,18 +21,8 @@ public class ChatAttach extends BaseSoftDeleteByAnnotation {
     private ChatMessage chatMessage;
 
     // 첨부파일은 파일 정보와 1:1 매핑된다.
-    @OneToOne(cascade = CascadeType.REMOVE, orphanRemoval = true, optional = false)
+    @OneToOne(optional = false)
     @JoinColumn(name = "file_info_id", nullable = false)
     private FileInfo fileInfo;
-
-    //Soft-Delete 전파
-    @Override
-    public void onSoftDelete() {
-        super.onSoftDelete();
-        if (fileInfo != null) {
-            fileInfo.markDeleted(); // soft-delete 전파
-        }
-    }
-
 
 }

--- a/src/main/java/com/pickteam/domain/chat/ChatAttach.java
+++ b/src/main/java/com/pickteam/domain/chat/ChatAttach.java
@@ -1,0 +1,25 @@
+package com.pickteam.domain.chat;
+
+import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.FileInfo;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatAttach extends BaseSoftDeleteByAnnotation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    private ChatMessage chatMessage;
+
+    @ManyToOne(optional = false)
+    private FileInfo fileInfo;
+}

--- a/src/main/java/com/pickteam/domain/chat/ChatAttach.java
+++ b/src/main/java/com/pickteam/domain/chat/ChatAttach.java
@@ -20,6 +20,19 @@ public class ChatAttach extends BaseSoftDeleteByAnnotation {
     @ManyToOne(optional = false)
     private ChatMessage chatMessage;
 
-    @ManyToOne(optional = false)
+    // 첨부파일은 파일 정보와 1:1 매핑된다.
+    @OneToOne(cascade = CascadeType.REMOVE, orphanRemoval = true, optional = false)
+    @JoinColumn(name = "file_info_id", nullable = false)
     private FileInfo fileInfo;
+
+    //Soft-Delete 전파
+    @Override
+    public void onSoftDelete() {
+        super.onSoftDelete();
+        if (fileInfo != null) {
+            fileInfo.markDeleted(); // soft-delete 전파
+        }
+    }
+
+
 }

--- a/src/main/java/com/pickteam/domain/chat/ChatMember.java
+++ b/src/main/java/com/pickteam/domain/chat/ChatMember.java
@@ -7,6 +7,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -17,6 +19,7 @@ import java.time.LocalDateTime;
 public class ChatMember extends BaseTimeEntity {
     //현재 멤버에 대한 생성정보만 사용할 것이므로 BaseTimeEntity를 상속받는다.
     //입-퇴장 로그는 이 테이블에서 Soft-Delete 처리하지 않고, 필요 시 별도의 로그를 통해 관리한다.
+    //(로그성 정보가 이 테이블에 쌓일 경우, 입퇴장이 반복때마다 soft-delete 정보가 쌓여서 테이블이 무거워진다.)
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/pickteam/domain/chat/ChatMember.java
+++ b/src/main/java/com/pickteam/domain/chat/ChatMember.java
@@ -16,10 +16,8 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class ChatMember extends BaseTimeEntity {
-    //현재 멤버에 대한 생성정보만 사용할 것이므로 BaseTimeEntity를 상속받는다.
-    //입-퇴장 로그는 이 테이블에서 Soft-Delete 처리하지 않고, 필요 시 별도의 로그를 통해 관리한다.
-    //(로그성 정보가 이 테이블에 쌓일 경우, 입퇴장이 반복때마다 soft-delete 정보가 쌓여서 테이블이 무거워진다.)
+public class ChatMember extends BaseSoftDeleteByAnnotation {
+    //Soft-Delete 방식으로 설계변경
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/pickteam/domain/chat/ChatMember.java
+++ b/src/main/java/com/pickteam/domain/chat/ChatMember.java
@@ -1,0 +1,30 @@
+package com.pickteam.domain.chat;
+
+import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.BaseTimeEntity;
+import com.pickteam.domain.user.Account;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatMember extends BaseTimeEntity {
+    //현재 멤버에 대한 생성정보만 사용할 것이므로 BaseTimeEntity를 상속받는다.
+    //입-퇴장 로그는 이 테이블에서 Soft-Delete 처리하지 않고, 필요 시 별도의 로그를 통해 관리한다.
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    private ChatRoom chatRoom;
+
+    @ManyToOne(optional = false)
+    private Account account;
+}

--- a/src/main/java/com/pickteam/domain/chat/ChatMessage.java
+++ b/src/main/java/com/pickteam/domain/chat/ChatMessage.java
@@ -1,0 +1,27 @@
+package com.pickteam.domain.chat;
+
+import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
+import com.pickteam.domain.user.Account;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatMessage extends BaseSoftDeleteSupportEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String content;
+
+    @ManyToOne(optional = false)
+    private ChatRoom chatRoom;
+
+    @ManyToOne(optional = false)
+    private Account account;
+}

--- a/src/main/java/com/pickteam/domain/chat/ChatMessage.java
+++ b/src/main/java/com/pickteam/domain/chat/ChatMessage.java
@@ -1,9 +1,13 @@
 package com.pickteam.domain.chat;
 
+import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
 import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
 import com.pickteam.domain.user.Account;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -11,7 +15,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class ChatMessage extends BaseSoftDeleteSupportEntity {
+public class ChatMessage extends BaseSoftDeleteByAnnotation {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,4 +28,18 @@ public class ChatMessage extends BaseSoftDeleteSupportEntity {
 
     @ManyToOne(optional = false)
     private Account account;
+
+    @OneToMany(mappedBy = "chatMessage", orphanRemoval = true)
+    private List<ChatAttach> attachments = new ArrayList<>();
+
+    // Soft-Delete 시, @SoftDelete 어노테이션은 자식객체에게 soft-delete를 전파해주지 않는다.
+    // Soft-Delete 동작 전파를 위해 OnSoftDelete를 오버라이드 (검증 필요함)
+
+    @Override
+    public void onSoftDelete() {
+        super.onSoftDelete();
+        attachments.forEach(BaseSoftDeleteByAnnotation::markDeleted);
+    }
+
+
 }

--- a/src/main/java/com/pickteam/domain/chat/ChatMessage.java
+++ b/src/main/java/com/pickteam/domain/chat/ChatMessage.java
@@ -29,17 +29,7 @@ public class ChatMessage extends BaseSoftDeleteByAnnotation {
     @ManyToOne(optional = false)
     private Account account;
 
-    @OneToMany(mappedBy = "chatMessage", orphanRemoval = true)
+    @OneToMany(mappedBy = "chatMessage")
     private List<ChatAttach> attachments = new ArrayList<>();
-
-    // Soft-Delete 시, @SoftDelete 어노테이션은 자식객체에게 soft-delete를 전파해주지 않는다.
-    // Soft-Delete 동작 전파를 위해 OnSoftDelete를 오버라이드 (검증 필요함)
-
-    @Override
-    public void onSoftDelete() {
-        super.onSoftDelete();
-        attachments.forEach(BaseSoftDeleteByAnnotation::markDeleted);
-    }
-
 
 }

--- a/src/main/java/com/pickteam/domain/chat/ChatRoom.java
+++ b/src/main/java/com/pickteam/domain/chat/ChatRoom.java
@@ -1,9 +1,14 @@
 package com.pickteam.domain.chat;
 
+import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.enums.ChatRoomType;
 import com.pickteam.domain.workspace.Workspace;
 import com.pickteam.domain.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -11,7 +16,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class ChatRoom extends BaseTimeEntity {
+public class ChatRoom extends BaseSoftDeleteByAnnotation {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,4 +29,21 @@ public class ChatRoom extends BaseTimeEntity {
 
     @ManyToOne(optional = false)
     private Workspace workspace;
+
+
+    @OneToMany(mappedBy = "chatRoom", orphanRemoval = true)
+    private List<ChatMessage> chatMessages = new ArrayList<>();
+
+    @OneToMany(mappedBy = "chatRoom", orphanRemoval = true)
+    private List<ChatMember> chatMembers = new ArrayList<>();
+
+    @Override
+    public void onSoftDelete() {
+        super.onSoftDelete();
+        chatMessages.forEach(BaseSoftDeleteByAnnotation::markDeleted);
+
+    }
+
+
+
 }

--- a/src/main/java/com/pickteam/domain/chat/ChatRoom.java
+++ b/src/main/java/com/pickteam/domain/chat/ChatRoom.java
@@ -37,13 +37,5 @@ public class ChatRoom extends BaseSoftDeleteByAnnotation {
     @OneToMany(mappedBy = "chatRoom", orphanRemoval = true)
     private List<ChatMember> chatMembers = new ArrayList<>();
 
-    @Override
-    public void onSoftDelete() {
-        super.onSoftDelete();
-        chatMessages.forEach(BaseSoftDeleteByAnnotation::markDeleted);
-
-    }
-
-
 
 }

--- a/src/main/java/com/pickteam/domain/chat/ChatRoom.java
+++ b/src/main/java/com/pickteam/domain/chat/ChatRoom.java
@@ -1,0 +1,27 @@
+package com.pickteam.domain.chat;
+
+import com.pickteam.domain.workspace.Workspace;
+import com.pickteam.domain.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatRoom extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private ChatRoomType type;
+
+    @ManyToOne(optional = false)
+    private Workspace workspace;
+}

--- a/src/main/java/com/pickteam/domain/common/BaseSoftDeleteByAnnotation.java
+++ b/src/main/java/com/pickteam/domain/common/BaseSoftDeleteByAnnotation.java
@@ -6,7 +6,6 @@ import jakarta.persistence.PreRemove;
 import lombok.Getter;
 import org.hibernate.annotations.SoftDelete;
 
-
 import java.time.LocalDateTime;
 
 /**
@@ -25,7 +24,13 @@ public abstract class BaseSoftDeleteByAnnotation extends BaseTimeEntity {
 
     @PreRemove
     public void onSoftDelete() {
-        this.deletedAt = LocalDateTime.now(); // Hibernate가 해주지 않음!
+        this.deletedAt = LocalDateTime.now(); // Hibernate가 해주지 않는다.
+    }
+
+    /** isDeleted 컬럼의 값을 수동 관리 필요할 경우를 위한 수동설정 메소드 (Hibernate가 관리해주지 않을 경우) */
+    public void markDeleted() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
     }
 
     public void restore() {

--- a/src/main/java/com/pickteam/domain/common/BaseSoftDeleteByAnnotation.java
+++ b/src/main/java/com/pickteam/domain/common/BaseSoftDeleteByAnnotation.java
@@ -1,0 +1,39 @@
+package com.pickteam.domain.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PreRemove;
+import lombok.Getter;
+import org.hibernate.annotations.SoftDelete;
+
+
+import java.time.LocalDateTime;
+
+/**
+ * Hibernate 6.4+ @SoftDelete 기반 soft-delete 추상 엔티티
+ */
+@Getter
+@MappedSuperclass
+@SoftDelete(columnName = "is_deleted")
+public abstract class BaseSoftDeleteByAnnotation extends BaseTimeEntity {
+
+    @Column(name = "is_deleted", insertable = false, updatable = false, nullable = false)
+    protected Boolean isDeleted = false;
+
+    @Column(name = "deleted_at")
+    protected LocalDateTime deletedAt;
+
+    @PreRemove
+    public void onSoftDelete() {
+        this.deletedAt = LocalDateTime.now(); // Hibernate가 해주지 않음!
+    }
+
+    public void restore() {
+        this.isDeleted = false;
+        this.deletedAt = null;
+    }
+
+    public boolean isActive() {
+        return !Boolean.TRUE.equals(this.isDeleted);
+    }
+}

--- a/src/main/java/com/pickteam/domain/common/BaseSoftDeleteSupportEntity.java
+++ b/src/main/java/com/pickteam/domain/common/BaseSoftDeleteSupportEntity.java
@@ -1,0 +1,35 @@
+package com.pickteam.domain.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * Soft-Delete를 수동 관리하는 코드
+ */
+@Getter
+@MappedSuperclass
+public abstract class BaseSoftDeleteSupportEntity extends BaseTimeEntity {
+
+    @Column(name="is_deleted", nullable = false)
+    protected Boolean isDeleted = false;
+
+    @Column(name="deleted_at")
+    protected LocalDateTime deletedAt;
+
+    public void markDeleted() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public void restore() {
+        this.isDeleted = false;
+        this.deletedAt = null;
+    }
+
+    public boolean isActive() {
+        return !Boolean.TRUE.equals(this.isDeleted);
+    }
+}

--- a/src/main/java/com/pickteam/domain/common/BaseSoftDeleteSupportEntity.java
+++ b/src/main/java/com/pickteam/domain/common/BaseSoftDeleteSupportEntity.java
@@ -7,8 +7,9 @@ import lombok.Getter;
 import java.time.LocalDateTime;
 
 /**
- * Soft-Delete를 수동 관리하는 코드
+ * Soft-Delete를 수동 관리하는 코드 (Deprecated)
  */
+
 @Getter
 @MappedSuperclass
 public abstract class BaseSoftDeleteSupportEntity extends BaseTimeEntity {

--- a/src/main/java/com/pickteam/domain/common/BaseTimeEntity.java
+++ b/src/main/java/com/pickteam/domain/common/BaseTimeEntity.java
@@ -1,0 +1,37 @@
+package com.pickteam.domain.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 공통적으로 사용되는 타임스탬프 관련 컬럼을 MappedSuperclass 어노테이션을 통해 관리
+ * updated
+ */
+@MappedSuperclass
+@Getter
+public abstract class BaseTimeEntity {
+
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    //EntityManager.persist() 호출 시 실행, 해당 컬럼의 값을 현재 시간으로 수정 (CreatedDate와 같은 역할)
+    protected void onCreate() {
+        this.createdAt = this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    // flush/commit 시 실행, 해당 컬럼의 값을 현재 시간으로 수정 (LastModifiedDate와 같은 역할)
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/pickteam/domain/common/FileInfo.java
+++ b/src/main/java/com/pickteam/domain/common/FileInfo.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class FileInfo {
+public class FileInfo extends BaseSoftDeleteByAnnotation {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/pickteam/domain/common/FileInfo.java
+++ b/src/main/java/com/pickteam/domain/common/FileInfo.java
@@ -1,0 +1,31 @@
+package com.pickteam.domain.common;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FileInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String nameOrigin;
+
+    private String nameHashed;
+
+    private Long size;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime deletedAt;
+
+    private Boolean isDeleted;
+}

--- a/src/main/java/com/pickteam/domain/enums/ChatRoomType.java
+++ b/src/main/java/com/pickteam/domain/enums/ChatRoomType.java
@@ -1,0 +1,5 @@
+package com.pickteam.domain.chat;
+
+public enum ChatRoomType {
+    GROUP, PERSONAL
+}

--- a/src/main/java/com/pickteam/domain/enums/ChatRoomType.java
+++ b/src/main/java/com/pickteam/domain/enums/ChatRoomType.java
@@ -1,4 +1,4 @@
-package com.pickteam.domain.chat;
+package com.pickteam.domain.enums;
 
 public enum ChatRoomType {
     GROUP, PERSONAL

--- a/src/main/java/com/pickteam/domain/enums/UserRole.java
+++ b/src/main/java/com/pickteam/domain/enums/UserRole.java
@@ -1,0 +1,6 @@
+package com.pickteam.domain.enums;
+
+public enum UserRole {
+    ADMIN,
+    USER
+}

--- a/src/main/java/com/pickteam/domain/kanban/Kanban.java
+++ b/src/main/java/com/pickteam/domain/kanban/Kanban.java
@@ -1,0 +1,26 @@
+package com.pickteam.domain.kanban;
+
+import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.team.Team;
+import com.pickteam.domain.workspace.Workspace;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Kanban extends BaseSoftDeleteByAnnotation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    private Team team;
+
+    @ManyToOne(optional = false)
+    private Workspace workspace;
+}

--- a/src/main/java/com/pickteam/domain/kanban/Kanban.java
+++ b/src/main/java/com/pickteam/domain/kanban/Kanban.java
@@ -27,13 +27,8 @@ public class Kanban extends BaseSoftDeleteByAnnotation {
     @ManyToOne(optional = false)
     private Workspace workspace;
 
-    @OneToMany(mappedBy = "kanban", orphanRemoval = true)
+    @OneToMany(mappedBy = "kanban")
     private List<KanbanList> kanbanLists = new ArrayList<>();
 
-    @Override
-    public void onSoftDelete() {
-        super.onSoftDelete();
-        kanbanLists.forEach(BaseSoftDeleteByAnnotation::markDeleted);
-    }
 }
 

--- a/src/main/java/com/pickteam/domain/kanban/Kanban.java
+++ b/src/main/java/com/pickteam/domain/kanban/Kanban.java
@@ -6,6 +6,9 @@ import com.pickteam.domain.workspace.Workspace;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Setter
@@ -23,4 +26,14 @@ public class Kanban extends BaseSoftDeleteByAnnotation {
 
     @ManyToOne(optional = false)
     private Workspace workspace;
+
+    @OneToMany(mappedBy = "kanban", orphanRemoval = true)
+    private List<KanbanList> kanbanLists = new ArrayList<>();
+
+    @Override
+    public void onSoftDelete() {
+        super.onSoftDelete();
+        kanbanLists.forEach(BaseSoftDeleteByAnnotation::markDeleted);
+    }
 }
+

--- a/src/main/java/com/pickteam/domain/kanban/KanbanList.java
+++ b/src/main/java/com/pickteam/domain/kanban/KanbanList.java
@@ -4,6 +4,9 @@ import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Setter
@@ -20,4 +23,14 @@ public class KanbanList extends BaseSoftDeleteByAnnotation {
 
     @ManyToOne(optional = false)
     private Kanban kanban;
+
+    @OneToMany(mappedBy = "kanbanList", orphanRemoval = true)
+    private List<KanbanTask> tasks = new ArrayList<>();
+
+    @Override
+    public void onSoftDelete() {
+        super.onSoftDelete();
+        tasks.forEach(BaseSoftDeleteByAnnotation::markDeleted);
+    }
+
 }

--- a/src/main/java/com/pickteam/domain/kanban/KanbanList.java
+++ b/src/main/java/com/pickteam/domain/kanban/KanbanList.java
@@ -1,0 +1,23 @@
+package com.pickteam.domain.kanban;
+
+import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class KanbanList extends BaseSoftDeleteByAnnotation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String kanbanListName;
+
+    @ManyToOne(optional = false)
+    private Kanban kanban;
+}

--- a/src/main/java/com/pickteam/domain/kanban/KanbanList.java
+++ b/src/main/java/com/pickteam/domain/kanban/KanbanList.java
@@ -24,13 +24,8 @@ public class KanbanList extends BaseSoftDeleteByAnnotation {
     @ManyToOne(optional = false)
     private Kanban kanban;
 
-    @OneToMany(mappedBy = "kanbanList", orphanRemoval = true)
+    @OneToMany(mappedBy = "kanbanList")
     private List<KanbanTask> tasks = new ArrayList<>();
 
-    @Override
-    public void onSoftDelete() {
-        super.onSoftDelete();
-        tasks.forEach(BaseSoftDeleteByAnnotation::markDeleted);
-    }
 
 }

--- a/src/main/java/com/pickteam/domain/kanban/KanbanTask.java
+++ b/src/main/java/com/pickteam/domain/kanban/KanbanTask.java
@@ -30,21 +30,13 @@ public class KanbanTask extends BaseSoftDeleteByAnnotation {
     @ManyToOne(optional = false)
     private KanbanList kanbanList;
 
-    @OneToMany(mappedBy = "kanbanTask", orphanRemoval = true)
+    @OneToMany(mappedBy = "kanbanTask")
     private List<KanbanTaskAttach> attachments = new ArrayList<>();
 
-    @OneToMany(mappedBy = "kanbanTask", orphanRemoval = true)
+    @OneToMany(mappedBy = "kanbanTask")
     private List<KanbanTaskComment> comments = new ArrayList<>();
 
-    @OneToMany(mappedBy = "kanbanTask", orphanRemoval = true)
+    @OneToMany(mappedBy = "kanbanTask")
     private List<KanbanTaskMember> members = new ArrayList<>();
-
-    @Override
-    public void markDeleted() {
-        super.markDeleted();
-        attachments.forEach(KanbanTaskAttach::markDeleted);
-        comments.forEach(KanbanTaskComment::markDeleted);
-        // members는 soft-delete 안 하기로 했으므로 제외
-    }
 
 }

--- a/src/main/java/com/pickteam/domain/kanban/KanbanTask.java
+++ b/src/main/java/com/pickteam/domain/kanban/KanbanTask.java
@@ -1,0 +1,27 @@
+package com.pickteam.domain.kanban;
+
+import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class KanbanTask extends BaseSoftDeleteSupportEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String subject;
+
+    private String content;
+
+    private java.time.LocalDateTime deadline;
+
+    @ManyToOne(optional = false)
+    private KanbanList kanbanList;
+}

--- a/src/main/java/com/pickteam/domain/kanban/KanbanTask.java
+++ b/src/main/java/com/pickteam/domain/kanban/KanbanTask.java
@@ -1,8 +1,12 @@
 package com.pickteam.domain.kanban;
 
+import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
 import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -10,7 +14,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class KanbanTask extends BaseSoftDeleteSupportEntity {
+public class KanbanTask extends BaseSoftDeleteByAnnotation {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -18,10 +22,29 @@ public class KanbanTask extends BaseSoftDeleteSupportEntity {
 
     private String subject;
 
+    @Lob
     private String content;
 
     private java.time.LocalDateTime deadline;
 
     @ManyToOne(optional = false)
     private KanbanList kanbanList;
+
+    @OneToMany(mappedBy = "kanbanTask", orphanRemoval = true)
+    private List<KanbanTaskAttach> attachments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "kanbanTask", orphanRemoval = true)
+    private List<KanbanTaskComment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "kanbanTask", orphanRemoval = true)
+    private List<KanbanTaskMember> members = new ArrayList<>();
+
+    @Override
+    public void markDeleted() {
+        super.markDeleted();
+        attachments.forEach(KanbanTaskAttach::markDeleted);
+        comments.forEach(KanbanTaskComment::markDeleted);
+        // members는 soft-delete 안 하기로 했으므로 제외
+    }
+
 }

--- a/src/main/java/com/pickteam/domain/kanban/KanbanTaskAttach.java
+++ b/src/main/java/com/pickteam/domain/kanban/KanbanTaskAttach.java
@@ -21,16 +21,8 @@ public class KanbanTaskAttach extends BaseSoftDeleteByAnnotation {
     private KanbanTask kanbanTask;
 
     // 첨부파일은 파일 정보와 1:1 매핑된다.
-    @OneToOne(cascade = CascadeType.REMOVE, orphanRemoval = true, optional = false)
+    @OneToOne(optional = false)
     @JoinColumn(name = "file_info_id", nullable = false)
     private FileInfo fileInfo;
-
-    @Override
-    public void onSoftDelete() {
-        super.onSoftDelete();
-        if (fileInfo != null) {
-            fileInfo.markDeleted(); // soft-delete 전파
-        }
-    }
 
 }

--- a/src/main/java/com/pickteam/domain/kanban/KanbanTaskAttach.java
+++ b/src/main/java/com/pickteam/domain/kanban/KanbanTaskAttach.java
@@ -1,0 +1,25 @@
+package com.pickteam.domain.kanban;
+
+import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.FileInfo;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class KanbanTaskAttach extends BaseSoftDeleteByAnnotation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    private KanbanTask kanbanTask;
+
+    @ManyToOne(optional = false)
+    private FileInfo fileInfo;
+}

--- a/src/main/java/com/pickteam/domain/kanban/KanbanTaskAttach.java
+++ b/src/main/java/com/pickteam/domain/kanban/KanbanTaskAttach.java
@@ -20,6 +20,17 @@ public class KanbanTaskAttach extends BaseSoftDeleteByAnnotation {
     @ManyToOne(optional = false)
     private KanbanTask kanbanTask;
 
-    @ManyToOne(optional = false)
+    // 첨부파일은 파일 정보와 1:1 매핑된다.
+    @OneToOne(cascade = CascadeType.REMOVE, orphanRemoval = true, optional = false)
+    @JoinColumn(name = "file_info_id", nullable = false)
     private FileInfo fileInfo;
+
+    @Override
+    public void onSoftDelete() {
+        super.onSoftDelete();
+        if (fileInfo != null) {
+            fileInfo.markDeleted(); // soft-delete 전파
+        }
+    }
+
 }

--- a/src/main/java/com/pickteam/domain/kanban/KanbanTaskComment.java
+++ b/src/main/java/com/pickteam/domain/kanban/KanbanTaskComment.java
@@ -1,0 +1,33 @@
+package com.pickteam.domain.kanban;
+
+import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.user.Account;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class KanbanTaskComment extends BaseSoftDeleteByAnnotation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String comment;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @ManyToOne(optional = false)
+    private KanbanTask kanbanTask;
+
+    @ManyToOne(optional = false)
+    private Account account;
+}

--- a/src/main/java/com/pickteam/domain/kanban/KanbanTaskComment.java
+++ b/src/main/java/com/pickteam/domain/kanban/KanbanTaskComment.java
@@ -19,11 +19,8 @@ public class KanbanTaskComment extends BaseSoftDeleteByAnnotation {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Lob
     private String comment;
-
-    private LocalDateTime createdAt;
-
-    private LocalDateTime updatedAt;
 
     @ManyToOne(optional = false)
     private KanbanTask kanbanTask;

--- a/src/main/java/com/pickteam/domain/kanban/KanbanTaskMember.java
+++ b/src/main/java/com/pickteam/domain/kanban/KanbanTaskMember.java
@@ -1,0 +1,27 @@
+package com.pickteam.domain.kanban;
+
+import com.pickteam.domain.common.BaseTimeEntity;
+import com.pickteam.domain.user.Account;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class KanbanTaskMember extends BaseTimeEntity {
+    //현재 멤버에 대한 생성정보만 사용할 것이므로 BaseTimeEntity를 상속받는다.
+    //입-퇴장 로그는 이 테이블에서 Soft-Delete 처리하지 않고, 필요 시 별도의 로그를 통해 관리한다.
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    private KanbanTask kanbanTask;
+
+    @ManyToOne(optional = false)
+    private Account account;
+}

--- a/src/main/java/com/pickteam/domain/kanban/KanbanTaskMember.java
+++ b/src/main/java/com/pickteam/domain/kanban/KanbanTaskMember.java
@@ -1,5 +1,6 @@
 package com.pickteam.domain.kanban;
 
+import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
 import com.pickteam.domain.common.BaseTimeEntity;
 import com.pickteam.domain.user.Account;
 import jakarta.persistence.*;
@@ -11,9 +12,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class KanbanTaskMember extends BaseTimeEntity {
-    //현재 멤버에 대한 생성정보만 사용할 것이므로 BaseTimeEntity를 상속받는다.
-    //입-퇴장 로그는 이 테이블에서 Soft-Delete 처리하지 않고, 필요 시 별도의 로그를 통해 관리한다.
+public class KanbanTaskMember extends BaseSoftDeleteByAnnotation {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/pickteam/domain/notification/NotificationLog.java
+++ b/src/main/java/com/pickteam/domain/notification/NotificationLog.java
@@ -1,5 +1,6 @@
 package com.pickteam.domain.notification;
 
+import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
 import com.pickteam.domain.common.BaseTimeEntity;
 import com.pickteam.domain.user.Account;
 import jakarta.persistence.*;
@@ -11,8 +12,10 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class NotificationLog extends BaseTimeEntity {
-    //알람은 soft-delete가 필요없는 정보다. 유저가 확인하면 날아가도 무방하다.
+public class NotificationLog extends BaseSoftDeleteByAnnotation {
+    //하드삭제 -> 소프트삭제로 설계변경. 유저가 확인하면 삭제되어도 무방하지만 운영상 관리 필요성 생길 수 있음
+    //즉시 삭제되지 않고 soft-delete 처리한 뒤 날짜기반으로 배치 삭제해도 무방
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/pickteam/domain/notification/NotificationLog.java
+++ b/src/main/java/com/pickteam/domain/notification/NotificationLog.java
@@ -1,0 +1,27 @@
+package com.pickteam.domain.notification;
+
+import com.pickteam.domain.common.BaseTimeEntity;
+import com.pickteam.domain.user.Account;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NotificationLog extends BaseTimeEntity {
+    //알람은 soft-delete가 필요없는 정보다. 유저가 확인하면 날아가도 무방하다.
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String content;
+
+    @Column(nullable = false)
+    private Boolean isRead = false;
+
+    @ManyToOne(optional = false)
+    private Account account;
+}

--- a/src/main/java/com/pickteam/domain/team/Team.java
+++ b/src/main/java/com/pickteam/domain/team/Team.java
@@ -28,21 +28,12 @@ public class Team extends BaseSoftDeleteByAnnotation {
     @ManyToOne(optional = false)
     private Workspace workspace;
 
-    // Team이 Hard-Delete로 사라지면 해당 팀에 귀속된 다음 값들도 함께 사라져야 한다.
-    @OneToMany(mappedBy = "team", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "team")
     private List<Board> boards = new ArrayList<>();
-    @OneToMany(mappedBy = "team", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "team")
     private List<Kanban> kanbans = new ArrayList<>();
-    @OneToMany(mappedBy = "team", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "team")
     private List<TeamMember> teamMembers = new ArrayList<>();
 
-    //soft-delete 전파
-    @Override
-    public void onSoftDelete() {
-        super.onSoftDelete();
-        boards.forEach(Board::markDeleted);
-        kanbans.forEach(Kanban::markDeleted);
-        teamMembers.forEach(TeamMember::markDeleted);
-    }
 
 }

--- a/src/main/java/com/pickteam/domain/team/Team.java
+++ b/src/main/java/com/pickteam/domain/team/Team.java
@@ -1,0 +1,39 @@
+package com.pickteam.domain.team;
+
+import com.pickteam.domain.board.Board;
+import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.kanban.Kanban;
+import com.pickteam.domain.workspace.Workspace;
+import com.pickteam.domain.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Team extends BaseSoftDeleteByAnnotation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @ManyToOne(optional = false)
+    private Workspace workspace;
+
+    // Team이 Hard-Delete로 사라지면 해당 팀에 귀속된 다음 값들도 함께 사라져야 한다.
+    @OneToMany(mappedBy = "team", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Board> boards = new ArrayList<>();
+    @OneToMany(mappedBy = "team", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Kanban> kanbans = new ArrayList<>();
+    @OneToMany(mappedBy = "team", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<TeamMember> teamMembers = new ArrayList<>();
+
+}

--- a/src/main/java/com/pickteam/domain/team/Team.java
+++ b/src/main/java/com/pickteam/domain/team/Team.java
@@ -36,4 +36,13 @@ public class Team extends BaseSoftDeleteByAnnotation {
     @OneToMany(mappedBy = "team", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<TeamMember> teamMembers = new ArrayList<>();
 
+    //soft-delete 전파
+    @Override
+    public void onSoftDelete() {
+        super.onSoftDelete();
+        boards.forEach(Board::markDeleted);
+        kanbans.forEach(Kanban::markDeleted);
+        teamMembers.forEach(TeamMember::markDeleted);
+    }
+
 }

--- a/src/main/java/com/pickteam/domain/team/TeamMember.java
+++ b/src/main/java/com/pickteam/domain/team/TeamMember.java
@@ -1,5 +1,6 @@
 package com.pickteam.domain.team;
 
+import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
 import com.pickteam.domain.common.BaseTimeEntity;
 import com.pickteam.domain.user.Account;
 import jakarta.persistence.*;
@@ -13,15 +14,12 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class TeamMember extends BaseTimeEntity {
-    //현재 멤버에 대한 생성정보만 사용할 것이므로 BaseTimeEntity를 상속받는다.
-    //입-퇴장 로그는 이 테이블에서 Soft-Delete 처리하지 않고, 필요 시 별도의 로그를 통해 관리한다.
+public class TeamMember extends BaseSoftDeleteByAnnotation {
+    //팀 탈퇴(혹은 추방)된 멤버에 대한 정보가 남아있어야 하므로... soft-delete 처리가 되어야 함
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    private LocalDateTime createdAt;
 
     @ManyToOne(optional = false)
     private Team team;

--- a/src/main/java/com/pickteam/domain/team/TeamMember.java
+++ b/src/main/java/com/pickteam/domain/team/TeamMember.java
@@ -1,0 +1,31 @@
+package com.pickteam.domain.team;
+
+import com.pickteam.domain.common.BaseTimeEntity;
+import com.pickteam.domain.user.Account;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TeamMember extends BaseTimeEntity {
+    //현재 멤버에 대한 생성정보만 사용할 것이므로 BaseTimeEntity를 상속받는다.
+    //입-퇴장 로그는 이 테이블에서 Soft-Delete 처리하지 않고, 필요 시 별도의 로그를 통해 관리한다.
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDateTime createdAt;
+
+    @ManyToOne(optional = false)
+    private Team team;
+
+    @ManyToOne(optional = false)
+    private Account account;
+}

--- a/src/main/java/com/pickteam/domain/user/Account.java
+++ b/src/main/java/com/pickteam/domain/user/Account.java
@@ -1,0 +1,60 @@
+package com.pickteam.domain.user;
+
+import com.pickteam.domain.board.Comment;
+import com.pickteam.domain.chat.ChatMember;
+import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.BaseTimeEntity;
+import com.pickteam.domain.enums.UserRole;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Account extends BaseSoftDeleteByAnnotation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private Integer age;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserRole role;
+
+    private String mbti;
+
+    private String disposition;
+
+    private String introduction;
+
+    private String portfolio;
+
+    private String preferWorkstyle;
+
+    private String dislikeWorkstyle;
+
+    @OneToMany(mappedBy = "account", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "account", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<ChatMember> chatMembers = new ArrayList<>();
+
+}

--- a/src/main/java/com/pickteam/domain/user/Account.java
+++ b/src/main/java/com/pickteam/domain/user/Account.java
@@ -1,10 +1,18 @@
 package com.pickteam.domain.user;
 
 import com.pickteam.domain.board.Comment;
+import com.pickteam.domain.board.Post;
 import com.pickteam.domain.chat.ChatMember;
+import com.pickteam.domain.chat.ChatMessage;
 import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
 import com.pickteam.domain.common.BaseTimeEntity;
 import com.pickteam.domain.enums.UserRole;
+import com.pickteam.domain.kanban.KanbanTaskComment;
+import com.pickteam.domain.kanban.KanbanTaskMember;
+import com.pickteam.domain.notification.NotificationLog;
+import com.pickteam.domain.team.TeamMember;
+import com.pickteam.domain.videochat.VideoMember;
+import com.pickteam.domain.workspace.WorkspaceMember;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -51,10 +59,37 @@ public class Account extends BaseSoftDeleteByAnnotation {
 
     private String dislikeWorkstyle;
 
-    @OneToMany(mappedBy = "account", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    // 사용자가 탈퇴해도 관련 정보가 삭제되면 안 된다. cascade 걸지 않고 OnetoMany로 연결만(조회용)
+    @OneToMany(mappedBy = "account")
     private List<Comment> comments = new ArrayList<>();
-
-    @OneToMany(mappedBy = "account", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "account")
     private List<ChatMember> chatMembers = new ArrayList<>();
+    @OneToMany(mappedBy = "account")
+    private List<ChatMessage> chatMessages = new ArrayList<>();
+    @OneToMany(mappedBy = "account")
+    private List<Post> posts = new ArrayList<>();
+    @OneToMany(mappedBy = "account")
+    private List<KanbanTaskComment> kanbanTaskComments = new ArrayList<>();
+    @OneToMany(mappedBy = "account")
+    private List<KanbanTaskMember> kanbanTaskMembers = new ArrayList<>();
+    @OneToMany(mappedBy = "account")
+    private List<NotificationLog> notificationLogs = new ArrayList<>();
+    @OneToMany(mappedBy = "account")
+    private List<TeamMember> teamMembers = new ArrayList<>();
+    @OneToMany(mappedBy = "account")
+    private List<VideoMember> videoMembers = new ArrayList<>();
+    @OneToMany(mappedBy = "account")
+    private List<WorkspaceMember> workspaceMembers = new ArrayList<>();
+    @OneToMany(mappedBy = "account")
+    private List<UserHashtagList> userHashtagLists = new ArrayList<>();
+
+    //워크스페이스에서 soft-delete되면 soft-delete 정보가 자식에게 전파되어야 한다
+    //hard-delete되면 안 된다
+    @Override
+    public void onSoftDelete() {
+        super.onSoftDelete();
+        teamMembers.forEach(TeamMember::markDeleted);
+        workspaceMembers.forEach(WorkspaceMember::markDeleted);
+    }
 
 }

--- a/src/main/java/com/pickteam/domain/user/Account.java
+++ b/src/main/java/com/pickteam/domain/user/Account.java
@@ -83,13 +83,5 @@ public class Account extends BaseSoftDeleteByAnnotation {
     @OneToMany(mappedBy = "account")
     private List<UserHashtagList> userHashtagLists = new ArrayList<>();
 
-    //워크스페이스에서 soft-delete되면 soft-delete 정보가 자식에게 전파되어야 한다
-    //hard-delete되면 안 된다
-    @Override
-    public void onSoftDelete() {
-        super.onSoftDelete();
-        teamMembers.forEach(TeamMember::markDeleted);
-        workspaceMembers.forEach(WorkspaceMember::markDeleted);
-    }
 
 }

--- a/src/main/java/com/pickteam/domain/user/UserHashtag.java
+++ b/src/main/java/com/pickteam/domain/user/UserHashtag.java
@@ -1,0 +1,22 @@
+package com.pickteam.domain.user;
+
+import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserHashtag extends BaseSoftDeleteSupportEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+}

--- a/src/main/java/com/pickteam/domain/user/UserHashtagList.java
+++ b/src/main/java/com/pickteam/domain/user/UserHashtagList.java
@@ -1,0 +1,24 @@
+package com.pickteam.domain.user;
+
+import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserHashtagList extends BaseSoftDeleteByAnnotation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    private Account account;
+
+    @ManyToOne(optional = false)
+    private UserHashtag userHashtag;
+}

--- a/src/main/java/com/pickteam/domain/user/UserHashtagList.java
+++ b/src/main/java/com/pickteam/domain/user/UserHashtagList.java
@@ -1,6 +1,8 @@
 package com.pickteam.domain.user;
 
 import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.team.TeamMember;
+import com.pickteam.domain.workspace.WorkspaceMember;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -21,4 +23,5 @@ public class UserHashtagList extends BaseSoftDeleteByAnnotation {
 
     @ManyToOne(optional = false)
     private UserHashtag userHashtag;
+
 }

--- a/src/main/java/com/pickteam/domain/videochat/VideoChannel.java
+++ b/src/main/java/com/pickteam/domain/videochat/VideoChannel.java
@@ -6,15 +6,16 @@ import com.pickteam.domain.workspace.Workspace;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class VideoChannel extends BaseTimeEntity {
-    //생성되어있는 현재 채널 목록 테이블은 속도를 위해 soft-delete 처리하지 않는다.
-    //생성 및 종료 내역이 필요할 경우 별도 테이블로 관리한다.
+public class VideoChannel extends BaseSoftDeleteByAnnotation {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,4 +25,8 @@ public class VideoChannel extends BaseTimeEntity {
 
     @ManyToOne(optional = false)
     private Workspace workspace;
+
+    @OneToMany(mappedBy = "videoChannel")
+    private List<VideoMember> members = new ArrayList<>();
+
 }

--- a/src/main/java/com/pickteam/domain/videochat/VideoChannel.java
+++ b/src/main/java/com/pickteam/domain/videochat/VideoChannel.java
@@ -1,0 +1,27 @@
+package com.pickteam.domain.videochat;
+
+import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.BaseTimeEntity;
+import com.pickteam.domain.workspace.Workspace;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VideoChannel extends BaseTimeEntity {
+    //생성되어있는 현재 채널 목록 테이블은 속도를 위해 soft-delete 처리하지 않는다.
+    //생성 및 종료 내역이 필요할 경우 별도 테이블로 관리한다.
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @ManyToOne(optional = false)
+    private Workspace workspace;
+}

--- a/src/main/java/com/pickteam/domain/videochat/VideoMember.java
+++ b/src/main/java/com/pickteam/domain/videochat/VideoMember.java
@@ -1,0 +1,31 @@
+package com.pickteam.domain.videochat;
+
+import com.pickteam.domain.common.BaseTimeEntity;
+import com.pickteam.domain.user.Account;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VideoMember extends BaseTimeEntity {
+    //현재 멤버에 대한 생성정보만 사용할 것이므로 BaseTimeEntity를 상속받는다.
+    //입-퇴장 로그는 이 테이블에서 Soft-Delete 처리하지 않고, 필요 시 별도의 로그를 통해 관리한다.
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDateTime createdAt;
+
+    @ManyToOne(optional = false)
+    private Account account;
+
+    @ManyToOne(optional = false)
+    private VideoChannel videoChannel;
+}

--- a/src/main/java/com/pickteam/domain/videochat/VideoMember.java
+++ b/src/main/java/com/pickteam/domain/videochat/VideoMember.java
@@ -1,5 +1,7 @@
 package com.pickteam.domain.videochat;
 
+import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
 import com.pickteam.domain.common.BaseTimeEntity;
 import com.pickteam.domain.user.Account;
 import jakarta.persistence.*;
@@ -13,9 +15,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class VideoMember extends BaseTimeEntity {
-    //현재 멤버에 대한 생성정보만 사용할 것이므로 BaseTimeEntity를 상속받는다.
-    //입-퇴장 로그는 이 테이블에서 Soft-Delete 처리하지 않고, 필요 시 별도의 로그를 통해 관리한다.
+public class VideoMember extends BaseSoftDeleteSupportEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,4 +28,5 @@ public class VideoMember extends BaseTimeEntity {
 
     @ManyToOne(optional = false)
     private VideoChannel videoChannel;
+
 }

--- a/src/main/java/com/pickteam/domain/workspace/Blacklist.java
+++ b/src/main/java/com/pickteam/domain/workspace/Blacklist.java
@@ -1,0 +1,25 @@
+package com.pickteam.domain.workspace;
+
+import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.user.Account;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Blacklist extends BaseSoftDeleteByAnnotation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    private Workspace workspace;
+
+    @ManyToOne(optional = false)
+    private Account account;
+}

--- a/src/main/java/com/pickteam/domain/workspace/Workspace.java
+++ b/src/main/java/com/pickteam/domain/workspace/Workspace.java
@@ -1,0 +1,31 @@
+package com.pickteam.domain.workspace;
+
+import com.pickteam.domain.common.BaseTimeEntity;
+import com.pickteam.domain.user.Account;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Workspace extends BaseTimeEntity {
+    //현재 멤버에 대한 생성정보만 사용할 것이므로 BaseTimeEntity를 상속받는다.
+    //입-퇴장 로그는 이 테이블에서 Soft-Delete 처리하지 않고, 필요 시 별도의 로그를 통해 관리한다.
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String password;
+
+    private String url;
+
+    @ManyToOne(optional = false)
+    private Account account;
+}

--- a/src/main/java/com/pickteam/domain/workspace/Workspace.java
+++ b/src/main/java/com/pickteam/domain/workspace/Workspace.java
@@ -1,9 +1,13 @@
 package com.pickteam.domain.workspace;
 
+import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
 import com.pickteam.domain.common.BaseTimeEntity;
 import com.pickteam.domain.user.Account;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -11,9 +15,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Workspace extends BaseTimeEntity {
-    //현재 멤버에 대한 생성정보만 사용할 것이므로 BaseTimeEntity를 상속받는다.
-    //입-퇴장 로그는 이 테이블에서 Soft-Delete 처리하지 않고, 필요 시 별도의 로그를 통해 관리한다.
+public class Workspace extends BaseSoftDeleteSupportEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,4 +30,9 @@ public class Workspace extends BaseTimeEntity {
 
     @ManyToOne(optional = false)
     private Account account;
+
+    @OneToMany(mappedBy = "workspace")
+    private List<WorkspaceMember> members = new ArrayList<>();
+
+
 }

--- a/src/main/java/com/pickteam/domain/workspace/WorkspaceMember.java
+++ b/src/main/java/com/pickteam/domain/workspace/WorkspaceMember.java
@@ -1,0 +1,31 @@
+package com.pickteam.domain.workspace;
+
+import com.pickteam.domain.common.BaseTimeEntity;
+import com.pickteam.domain.user.Account;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WorkspaceMember extends BaseTimeEntity {
+    //현재 멤버에 대한 생성정보만 사용할 것이므로 BaseTimeEntity를 상속받는다.
+    //입-퇴장 로그는 이 테이블에서 Soft-Delete 처리하지 않고, 필요 시 별도의 로그를 통해 관리한다. {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDateTime createdAt;
+
+    @ManyToOne(optional = false)
+    private Workspace workspace;
+
+    @ManyToOne(optional = false)
+    private Account account;
+}

--- a/src/main/java/com/pickteam/domain/workspace/WorkspaceMember.java
+++ b/src/main/java/com/pickteam/domain/workspace/WorkspaceMember.java
@@ -1,5 +1,6 @@
 package com.pickteam.domain.workspace;
 
+import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
 import com.pickteam.domain.common.BaseTimeEntity;
 import com.pickteam.domain.user.Account;
 import jakarta.persistence.*;
@@ -13,9 +14,8 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class WorkspaceMember extends BaseTimeEntity {
-    //현재 멤버에 대한 생성정보만 사용할 것이므로 BaseTimeEntity를 상속받는다.
-    //입-퇴장 로그는 이 테이블에서 Soft-Delete 처리하지 않고, 필요 시 별도의 로그를 통해 관리한다. {
+public class WorkspaceMember extends BaseSoftDeleteByAnnotation {
+    //유저가 탈퇴하거나 추방되어도 관련 정보가 삭제되면 안된다. soft-delete 처리한다.
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,9 +24,12 @@ spring.datasource.password=${DB_PASSWORD}
 spring.jpa.hibernate.ddl-auto=${JPA_DDL_AUTO}
 spring.jpa.show-sql=${JPA_SHOW_SQL}
 spring.jpa.open-in-view=${JPA_OPEN_IN_VIEW}
-#dialect 명시하는 부분 Deprecated됨 -> Spring에서 자동 감지한다.
-#spring.jpa.properties.hibernate.dialect=${JPA_DIALECT}
 spring.jpa.properties.hibernate.connection.characterEncoding=${DB_MYSQL_CHARACTER_SET_SERVER}
+
+#dialect 명시하는 부분 Deprecated됨 -> Spring에서 자동 감지한다.
+#Warn 뜨는 거 귀찮아서 일부러 주석처리한 것. 두 설정 모두 마찬가지임. hibernate쪽 옵션이 좀 더 현대적인 스펙임
+#spring.jpa.properties.hibernate.dialect=${JPA_DIALECT}
+# spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 
 #유니코드는 항시 사용하므로 true 고정
 spring.jpa.properties.hibernate.connection.useUnicode=true

--- a/src/test/java/com/pickteam/PickTeamApplicationTests.java
+++ b/src/test/java/com/pickteam/PickTeamApplicationTests.java
@@ -1,4 +1,4 @@
-package mvc.pickteam;
+package com.pickteam;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
스키마 구조 초안에 기반해 Entity 추가 및 일부 설계 변경 (컬럼명, 연관관계, soft-delete에 따른 컬럼 추가 등)
soft-delete 처리는 @SoftDelete 어노테이션을 통해 Hibernate가 처리하도록 설정
부모 엔티티 삭제 시 자식 엔티티가 같이 삭제되도록 하는 cascade 설정은 hibernate가 자동으로 처리해주지 않으므로 cascade를 사용하지 않고 명시적으로 수동 처리하도록 팀내 합의