### PR TITLE
Soft delete email policy

### DIFF
--- a/src/main/java/com/pickteam/config/SecurityConfig.java
+++ b/src/main/java/com/pickteam/config/SecurityConfig.java
@@ -59,7 +59,11 @@ public class SecurityConfig {
                 // URL 접근 권한 설정
                 .authorizeHttpRequests(auth -> auth
                         // 인증 없이 접근 가능한 URL
-                        .requestMatchers("/api/users/register", "/api/users/login").permitAll()
+                        .requestMatchers("/api/users/register", "/api/users/login", "/api/users/login/",
+                                "/api/users/login/enhanced")
+                        .permitAll()
+                        .requestMatchers("/api/users/logout", "/api/users/logout/", "/api/users/logout/enhanced")
+                        .permitAll()
                         .requestMatchers("/api/users/check-id", "/api/users/validate-password").permitAll()
                         .requestMatchers("/api/users/email/request", "/api/users/email/verify").permitAll()
 

--- a/src/main/java/com/pickteam/constants/UserErrorMessages.java
+++ b/src/main/java/com/pickteam/constants/UserErrorMessages.java
@@ -25,6 +25,11 @@ public class UserErrorMessages {
     public static final String EMAIL_NOT_VERIFIED = "이메일 인증이 완료되지 않았습니다.";
     public static final String INVALID_CURRENT_PASSWORD = "현재 비밀번호가 올바르지 않습니다.";
 
+    // 탈퇴 관련 메시지
+    public static final String ACCOUNT_UNDER_WITHDRAWAL = "해당 이메일은 탈퇴 처리 중입니다. 완전 삭제 예정일: %s (남은 일수: %d일)";
+    public static final String ACCOUNT_WITHDRAWAL_GRACE_PERIOD = "탈퇴한 계정의 유예 기간 중에는 동일한 이메일로 가입할 수 없습니다.";
+    public static final String EMAIL_VERIFICATION_BLOCKED_WITHDRAWAL = "탈퇴 처리 중인 계정의 이메일로는 인증을 진행할 수 없습니다.";
+
     // Private 생성자로 인스턴스화 방지
     private UserErrorMessages() {
         throw new AssertionError("상수 클래스는 인스턴스화할 수 없습니다.");

--- a/src/main/java/com/pickteam/controller/user/UserController.java
+++ b/src/main/java/com/pickteam/controller/user/UserController.java
@@ -548,6 +548,19 @@ public class UserController {
     }
 
     /**
+     * 계정 탈퇴 관련 예외 처리
+     * - 탈퇴 유예 기간 중인 계정으로 작업 시도 시 발생
+     * - 409 Conflict로 응답
+     */
+    @ExceptionHandler(com.pickteam.exception.AccountWithdrawalException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAccountWithdrawalException(
+            com.pickteam.exception.AccountWithdrawalException ex) {
+        log.warn("탈퇴 계정 관련 오류: {}", ex.getMessage());
+        ApiResponse<Void> response = ApiResponse.error(ex.getDetailedMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
+    }
+
+    /**
      * DataIntegrityViolationException 처리
      * - 데이터베이스 제약 조건 위반 시 발생
      * - 이메일 인증 중복 요청, 중복 이메일 등의 경우

--- a/src/main/java/com/pickteam/exception/AccountWithdrawalException.java
+++ b/src/main/java/com/pickteam/exception/AccountWithdrawalException.java
@@ -1,0 +1,57 @@
+package com.pickteam.exception;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * 탈퇴 계정 관련 예외
+ * - 탈퇴 유예 기간 중인 계정으로 시도한 작업에 대한 예외
+ * - 유예 기간 정보와 함께 사용자 친화적인 메시지 제공
+ */
+public class AccountWithdrawalException extends RuntimeException {
+
+    private final LocalDateTime permanentDeletionDate;
+    private final long remainingDays;
+
+    /**
+     * 탈퇴 계정 예외 생성자
+     * 
+     * @param message               기본 메시지
+     * @param permanentDeletionDate 완전 삭제 예정일
+     */
+    public AccountWithdrawalException(String message, LocalDateTime permanentDeletionDate) {
+        super(message);
+        this.permanentDeletionDate = permanentDeletionDate;
+        this.remainingDays = ChronoUnit.DAYS.between(LocalDateTime.now(), permanentDeletionDate);
+    }
+
+    /**
+     * 메시지만으로 생성하는 생성자
+     * 
+     * @param message 예외 메시지
+     */
+    public AccountWithdrawalException(String message) {
+        super(message);
+        this.permanentDeletionDate = null;
+        this.remainingDays = -1;
+    }
+
+    public LocalDateTime getPermanentDeletionDate() {
+        return permanentDeletionDate;
+    }
+
+    public long getRemainingDays() {
+        return remainingDays;
+    }
+
+    /**
+     * 유예 기간 정보가 포함된 상세 메시지 반환
+     */
+    public String getDetailedMessage() {
+        if (permanentDeletionDate != null) {
+            return String.format("해당 이메일은 탈퇴 처리 중입니다. 완전 삭제 예정일: %s (남은 일수: %d일)",
+                    permanentDeletionDate.toLocalDate(), remainingDays);
+        }
+        return getMessage();
+    }
+}

--- a/src/main/java/com/pickteam/repository/user/AccountRepository.java
+++ b/src/main/java/com/pickteam/repository/user/AccountRepository.java
@@ -74,4 +74,18 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
                         "AND a.permanentDeletionDate > CURRENT_TIMESTAMP " +
                         "AND a.deletedAt IS NOT NULL")
         List<Account> findAccountsInGracePeriod();
+
+        // 탈퇴 유예 기간 중인 특정 이메일 계정 조회
+        @Query("SELECT a FROM Account a WHERE a.email = :email " +
+                        "AND a.permanentDeletionDate IS NOT NULL " +
+                        "AND a.permanentDeletionDate > CURRENT_TIMESTAMP " +
+                        "AND a.deletedAt IS NOT NULL")
+        Optional<Account> findWithdrawnAccountByEmail(@Param("email") String email);
+
+        // 특정 이메일의 탈퇴 상태 확인
+        @Query("SELECT COUNT(a) > 0 FROM Account a WHERE a.email = :email " +
+                        "AND a.permanentDeletionDate IS NOT NULL " +
+                        "AND a.permanentDeletionDate > CURRENT_TIMESTAMP " +
+                        "AND a.deletedAt IS NOT NULL")
+        boolean existsWithdrawnAccountByEmail(@Param("email") String email);
 }

--- a/src/main/java/com/pickteam/service/security/AccountCleanupScheduler.java
+++ b/src/main/java/com/pickteam/service/security/AccountCleanupScheduler.java
@@ -1,0 +1,180 @@
+package com.pickteam.service.security;
+
+import com.pickteam.domain.user.Account;
+import com.pickteam.repository.user.AccountRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 계정 정리 스케줄러
+ * - 유예기간이 만료된 계정을 영구 삭제 (hard-delete)
+ * - 개인정보보호법 준수를 위한 자동 데이터 삭제
+ * - 스케줄링을 통한 주기적 정리 작업 수행
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AccountCleanupScheduler {
+
+    private final AccountRepository accountRepository;
+
+    /** 유예기간 (일) - 기본값: 30일 */
+    @Value("${app.account.grace-period-days:30}")
+    private int gracePeriodDays;
+
+    /**
+     * 유예기간 만료된 계정 영구 삭제
+     * - 매일 새벽 2시에 실행 (cron: 0 0 2 * * ?)
+     * - 개인정보보호법 준수를 위한 자동 삭제
+     * - 연관 데이터 정리 포함
+     */
+    @Scheduled(cron = "${app.account.cleanup-schedule:0 0 2 * * ?}")
+    @Transactional
+    public void cleanupExpiredAccounts() {
+        log.info("===== 계정 정리 스케줄러 시작 =====");
+
+        try {
+            // 영구 삭제 대상 계정 조회
+            List<Account> accountsToDelete = accountRepository.findAccountsToHardDelete();
+
+            if (accountsToDelete.isEmpty()) {
+                log.info("영구 삭제할 계정이 없습니다.");
+                return;
+            }
+
+            log.info("영구 삭제 대상 계정 수: {}개", accountsToDelete.size());
+
+            int deletedCount = 0;
+            for (Account account : accountsToDelete) {
+                try {
+                    // 연관 데이터 정리 (필요시)
+                    cleanupRelatedData(account);
+
+                    // 영구 삭제 (hard-delete)
+                    accountRepository.delete(account);
+                    deletedCount++;
+
+                    log.info("계정 영구 삭제 완료: ID={}, 이메일={}, 삭제예정일={}",
+                            account.getId(),
+                            maskEmail(account.getEmail()),
+                            account.getPermanentDeletionDate());
+
+                } catch (Exception e) {
+                    log.error("계정 영구 삭제 실패: ID={}, 이메일={}, 오류={}",
+                            account.getId(),
+                            maskEmail(account.getEmail()),
+                            e.getMessage(), e);
+                }
+            }
+
+            log.info("===== 계정 정리 스케줄러 완료: {}개 삭제 =====", deletedCount);
+
+        } catch (Exception e) {
+            log.error("계정 정리 스케줄러 실행 중 오류 발생", e);
+        }
+    }
+
+    /**
+     * 연관 데이터 정리
+     * - 사용자와 연관된 모든 데이터를 안전하게 처리
+     * - 비즈니스 로직에 따라 삭제 또는 익명화 수행
+     * 
+     * @param account 삭제할 계정
+     */
+    private void cleanupRelatedData(Account account) {
+        log.debug("연관 데이터 정리 시작: 계정 ID={}", account.getId());
+
+        // TODO: 실제 연관 데이터 정리 로직 구현
+        // 예시:
+        // 1. 댓글: 작성자 정보 익명화 또는 삭제
+        // 2. 채팅 메시지: 발송자 정보 익명화
+        // 3. 워크스페이스 멤버십: 삭제
+        // 4. 팀 멤버십: 삭제
+        // 5. 알림 로그: 삭제
+        // 6. 해시태그 연결: 삭제
+
+        // 현재는 로그만 남김 (실제 구현시 각 서비스별 정리 로직 호출)
+        log.debug("연관 데이터 정리 필요: 댓글={}, 채팅메시지={}, 워크스페이스멤버={}, 팀멤버={}",
+                account.getComments().size(),
+                account.getChatMessages().size(),
+                account.getWorkspaceMembers().size(),
+                account.getTeamMembers().size());
+    }
+
+    /**
+     * 이메일 마스킹 (개인정보 보호)
+     * - 로그에 이메일 출력 시 개인정보 보호를 위해 마스킹
+     * 
+     * @param email 원본 이메일
+     * @return 마스킹된 이메일
+     */
+    private String maskEmail(String email) {
+        if (email == null || email.length() < 3) {
+            return "***";
+        }
+
+        int atIndex = email.indexOf('@');
+        if (atIndex == -1) {
+            return email.substring(0, 2) + "***";
+        }
+
+        String localPart = email.substring(0, atIndex);
+        String domainPart = email.substring(atIndex);
+
+        if (localPart.length() <= 2) {
+            return localPart.charAt(0) + "***" + domainPart;
+        } else {
+            return localPart.substring(0, 2) + "***" + domainPart;
+        }
+    }
+
+    /**
+     * 현재 유예기간 만료 예정 계정 수 조회
+     * - 모니터링 및 알림 용도
+     * 
+     * @return 영구 삭제 예정 계정 수
+     */
+    public long getAccountsScheduledForDeletionCount() {
+        return accountRepository.countAccountsToHardDelete();
+    }
+
+    /**
+     * 유예기간 내 복구 가능한 계정 목록 조회
+     * - 관리자용 복구 기능
+     * 
+     * @return 복구 가능한 계정 목록
+     */
+    public List<Account> getAccountsInGracePeriod() {
+        return accountRepository.findAccountsInGracePeriod();
+    }
+
+    /**
+     * 수동으로 특정 기간 이전 계정 정리
+     * - 관리자 전용 기능
+     * - 비상시 또는 대량 정리가 필요한 경우
+     * 
+     * @param cutoffDate 기준 날짜 (이 날짜 이전에 삭제 예정인 계정들 삭제)
+     * @return 삭제된 계정 수
+     */
+    @Transactional
+    public int manualCleanupAccountsBefore(LocalDateTime cutoffDate) {
+        log.warn("수동 계정 정리 시작: 기준일={}", cutoffDate);
+
+        List<Account> accountsToDelete = accountRepository.findAccountsToHardDeleteBefore(cutoffDate);
+
+        for (Account account : accountsToDelete) {
+            cleanupRelatedData(account);
+            accountRepository.delete(account);
+        }
+
+        log.warn("수동 계정 정리 완료: {}개 삭제", accountsToDelete.size());
+        return accountsToDelete.size();
+    }
+}

--- a/src/main/java/com/pickteam/service/user/UserServiceImpl.java
+++ b/src/main/java/com/pickteam/service/user/UserServiceImpl.java
@@ -364,10 +364,11 @@ public class UserServiceImpl implements UserService {
         Account account = accountRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new UserNotFoundException(UserErrorMessages.USER_NOT_FOUND));
 
-        // Soft Delete 실행
-        account.markDeleted();
+        // Soft Delete 실행 (유예기간 설정)
+        account.markDeletedWithDefaultGracePeriod();
         accountRepository.save(account);
-        log.info("계정 삭제 완료: userId={}", userId);
+        log.info("계정 삭제 완료 (유예기간 {}일): userId={}, permanentDeletionDate={}",
+                30, userId, account.getPermanentDeletionDate());
     }
 
     /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -57,3 +57,7 @@ app.jwt.secret=${JWT_SECRET}
 app.jwt.expiration=${JWT_EXPIRATION}
 app.jwt.refresh-expiration=${JWT_REFRESH_EXPIRATION}
 app.jwt.refresh-token.expiration-days=${JWT_REFRESH_TOKEN_EXPIRATION_DAYS}
+
+# 계정 삭제 관련 설정
+app.account.grace-period-days=${ACCOUNT_GRACE_PERIOD_DAYS:30}
+app.account.cleanup-schedule=${ACCOUNT_CLEANUP_SCHEDULE:0 0 2 * * ?}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 계정 삭제 시 30일 유예 기간(그레이스 피리어드) 후 영구 삭제되는 기능이 추가되었습니다.
  * 계정 삭제 유예 기간 내에는 동일 이메일로 재가입 및 이메일 인증이 제한됩니다.
  * 관리자용 계정 영구 삭제 스케줄러 및 수동 정리 기능이 도입되었습니다.

* **버그 수정**
  * 이메일 인증 및 회원가입 시, 삭제 유예 중인 계정 이메일로는 진행이 차단됩니다.

* **설정**
  * 계정 삭제 유예 기간과 정리 스케줄(기본: 매일 새벽 2시) 설정이 추가되었습니다.

* **오류 메시지 및 예외 처리**
  * 삭제 유예 중인 계정 관련 상세 오류 메시지 및 예외 응답이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->