### PR TITLE
Soft-Delete 정책 변경에 따른 이슈 수정을 위한 상속 변경

### DIFF
--- a/src/main/java/com/pickteam/domain/board/Board.java
+++ b/src/main/java/com/pickteam/domain/board/Board.java
@@ -1,6 +1,7 @@
 package com.pickteam.domain.board;
 
 import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
 import com.pickteam.domain.common.BaseTimeEntity;
 import com.pickteam.domain.team.Team;
 import jakarta.persistence.*;
@@ -15,7 +16,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Board extends BaseSoftDeleteByAnnotation {
+public class Board extends BaseSoftDeleteSupportEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/pickteam/domain/board/Comment.java
+++ b/src/main/java/com/pickteam/domain/board/Comment.java
@@ -12,7 +12,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Comment extends BaseSoftDeleteByAnnotation {
+public class Comment extends BaseSoftDeleteSupportEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/pickteam/domain/board/Post.java
+++ b/src/main/java/com/pickteam/domain/board/Post.java
@@ -1,6 +1,7 @@
 package com.pickteam.domain.board;
 
 import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
 import com.pickteam.domain.user.Account;
 import jakarta.persistence.*;
 import lombok.*;
@@ -15,7 +16,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Post extends BaseSoftDeleteByAnnotation {
+public class Post extends BaseSoftDeleteSupportEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/pickteam/domain/board/PostAttach.java
+++ b/src/main/java/com/pickteam/domain/board/PostAttach.java
@@ -1,6 +1,7 @@
 package com.pickteam.domain.board;
 
 import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
 import com.pickteam.domain.common.FileInfo;
 import jakarta.persistence.*;
 import lombok.*;
@@ -11,7 +12,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class PostAttach extends BaseSoftDeleteByAnnotation {
+public class PostAttach extends BaseSoftDeleteSupportEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/pickteam/domain/chat/ChatAttach.java
+++ b/src/main/java/com/pickteam/domain/chat/ChatAttach.java
@@ -1,6 +1,7 @@
 package com.pickteam.domain.chat;
 
 import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
 import com.pickteam.domain.common.FileInfo;
 import jakarta.persistence.*;
 import lombok.*;
@@ -11,7 +12,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class ChatAttach extends BaseSoftDeleteByAnnotation {
+public class ChatAttach extends BaseSoftDeleteSupportEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/pickteam/domain/chat/ChatMember.java
+++ b/src/main/java/com/pickteam/domain/chat/ChatMember.java
@@ -1,6 +1,7 @@
 package com.pickteam.domain.chat;
 
 import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
 import com.pickteam.domain.common.BaseTimeEntity;
 import com.pickteam.domain.user.Account;
 import jakarta.persistence.*;
@@ -16,7 +17,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class ChatMember extends BaseSoftDeleteByAnnotation {
+public class ChatMember extends BaseSoftDeleteSupportEntity {
     //Soft-Delete 방식으로 설계변경
 
     @Id

--- a/src/main/java/com/pickteam/domain/chat/ChatMessage.java
+++ b/src/main/java/com/pickteam/domain/chat/ChatMessage.java
@@ -15,7 +15,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class ChatMessage extends BaseSoftDeleteByAnnotation {
+public class ChatMessage extends BaseSoftDeleteSupportEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/pickteam/domain/chat/ChatRoom.java
+++ b/src/main/java/com/pickteam/domain/chat/ChatRoom.java
@@ -1,6 +1,7 @@
 package com.pickteam.domain.chat;
 
 import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
 import com.pickteam.domain.enums.ChatRoomType;
 import com.pickteam.domain.workspace.Workspace;
 import com.pickteam.domain.common.BaseTimeEntity;
@@ -16,7 +17,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class ChatRoom extends BaseSoftDeleteByAnnotation {
+public class ChatRoom extends BaseSoftDeleteSupportEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/pickteam/domain/common/FileInfo.java
+++ b/src/main/java/com/pickteam/domain/common/FileInfo.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class FileInfo extends BaseSoftDeleteByAnnotation {
+public class FileInfo extends BaseSoftDeleteSupportEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/pickteam/domain/kanban/Kanban.java
+++ b/src/main/java/com/pickteam/domain/kanban/Kanban.java
@@ -1,6 +1,7 @@
 package com.pickteam.domain.kanban;
 
 import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
 import com.pickteam.domain.team.Team;
 import com.pickteam.domain.workspace.Workspace;
 import jakarta.persistence.*;
@@ -15,7 +16,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Kanban extends BaseSoftDeleteByAnnotation {
+public class Kanban extends BaseSoftDeleteSupportEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/pickteam/domain/kanban/KanbanList.java
+++ b/src/main/java/com/pickteam/domain/kanban/KanbanList.java
@@ -1,6 +1,7 @@
 package com.pickteam.domain.kanban;
 
 import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -13,7 +14,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class KanbanList extends BaseSoftDeleteByAnnotation {
+public class KanbanList extends BaseSoftDeleteSupportEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/pickteam/domain/kanban/KanbanTask.java
+++ b/src/main/java/com/pickteam/domain/kanban/KanbanTask.java
@@ -14,7 +14,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class KanbanTask extends BaseSoftDeleteByAnnotation {
+public class KanbanTask extends BaseSoftDeleteSupportEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/pickteam/domain/kanban/KanbanTaskAttach.java
+++ b/src/main/java/com/pickteam/domain/kanban/KanbanTaskAttach.java
@@ -1,6 +1,7 @@
 package com.pickteam.domain.kanban;
 
 import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
 import com.pickteam.domain.common.FileInfo;
 import jakarta.persistence.*;
 import lombok.*;
@@ -11,7 +12,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class KanbanTaskAttach extends BaseSoftDeleteByAnnotation {
+public class KanbanTaskAttach extends BaseSoftDeleteSupportEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/pickteam/domain/kanban/KanbanTaskComment.java
+++ b/src/main/java/com/pickteam/domain/kanban/KanbanTaskComment.java
@@ -1,6 +1,7 @@
 package com.pickteam.domain.kanban;
 
 import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
 import com.pickteam.domain.user.Account;
 import jakarta.persistence.*;
 import lombok.*;
@@ -13,7 +14,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class KanbanTaskComment extends BaseSoftDeleteByAnnotation {
+public class KanbanTaskComment extends BaseSoftDeleteSupportEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/pickteam/domain/kanban/KanbanTaskMember.java
+++ b/src/main/java/com/pickteam/domain/kanban/KanbanTaskMember.java
@@ -1,6 +1,7 @@
 package com.pickteam.domain.kanban;
 
 import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
 import com.pickteam.domain.common.BaseTimeEntity;
 import com.pickteam.domain.user.Account;
 import jakarta.persistence.*;
@@ -12,7 +13,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class KanbanTaskMember extends BaseSoftDeleteByAnnotation {
+public class KanbanTaskMember extends BaseSoftDeleteSupportEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/pickteam/domain/notification/NotificationLog.java
+++ b/src/main/java/com/pickteam/domain/notification/NotificationLog.java
@@ -1,6 +1,7 @@
 package com.pickteam.domain.notification;
 
 import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
 import com.pickteam.domain.common.BaseTimeEntity;
 import com.pickteam.domain.user.Account;
 import jakarta.persistence.*;
@@ -12,7 +13,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class NotificationLog extends BaseSoftDeleteByAnnotation {
+public class NotificationLog extends BaseSoftDeleteSupportEntity {
     //하드삭제 -> 소프트삭제로 설계변경. 유저가 확인하면 삭제되어도 무방하지만 운영상 관리 필요성 생길 수 있음
     //즉시 삭제되지 않고 soft-delete 처리한 뒤 날짜기반으로 배치 삭제해도 무방
 

--- a/src/main/java/com/pickteam/domain/schedule/Schedule.java
+++ b/src/main/java/com/pickteam/domain/schedule/Schedule.java
@@ -1,6 +1,7 @@
 package com.pickteam.domain.schedule;
 
 import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
 import com.pickteam.domain.team.Team;
 import com.pickteam.domain.user.Account;
 import jakarta.persistence.*;
@@ -14,7 +15,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Schedule extends BaseSoftDeleteByAnnotation {
+public class Schedule extends BaseSoftDeleteSupportEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/pickteam/domain/team/Team.java
+++ b/src/main/java/com/pickteam/domain/team/Team.java
@@ -2,6 +2,7 @@ package com.pickteam.domain.team;
 
 import com.pickteam.domain.board.Board;
 import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
 import com.pickteam.domain.kanban.Kanban;
 import com.pickteam.domain.workspace.Workspace;
 import jakarta.persistence.*;
@@ -16,7 +17,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Team extends BaseSoftDeleteByAnnotation {
+public class Team extends BaseSoftDeleteSupportEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/pickteam/domain/team/TeamMember.java
+++ b/src/main/java/com/pickteam/domain/team/TeamMember.java
@@ -1,6 +1,7 @@
 package com.pickteam.domain.team;
 
 import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
 import com.pickteam.domain.common.BaseTimeEntity;
 import com.pickteam.domain.user.Account;
 import jakarta.persistence.*;
@@ -14,7 +15,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class TeamMember extends BaseSoftDeleteByAnnotation {
+public class TeamMember extends BaseSoftDeleteSupportEntity {
     //팀 탈퇴(혹은 추방)된 멤버에 대한 정보가 남아있어야 하므로... soft-delete 처리가 되어야 함
 
     @Id

--- a/src/main/java/com/pickteam/domain/user/Account.java
+++ b/src/main/java/com/pickteam/domain/user/Account.java
@@ -5,6 +5,7 @@ import com.pickteam.domain.board.Post;
 import com.pickteam.domain.chat.ChatMember;
 import com.pickteam.domain.chat.ChatMessage;
 import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
 import com.pickteam.domain.enums.UserRole;
 import com.pickteam.domain.kanban.KanbanTaskComment;
 import com.pickteam.domain.kanban.KanbanTaskMember;
@@ -32,7 +33,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Account extends BaseSoftDeleteByAnnotation {
+public class Account extends BaseSoftDeleteSupportEntity {
 
     /** 사용자 고유 식별자 */
     @Id

--- a/src/main/java/com/pickteam/domain/user/UserHashtagList.java
+++ b/src/main/java/com/pickteam/domain/user/UserHashtagList.java
@@ -1,6 +1,7 @@
 package com.pickteam.domain.user;
 
 import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
 import com.pickteam.domain.team.TeamMember;
 import com.pickteam.domain.workspace.WorkspaceMember;
 import jakarta.persistence.*;
@@ -19,7 +20,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class UserHashtagList extends BaseSoftDeleteByAnnotation {
+public class UserHashtagList extends BaseSoftDeleteSupportEntity {
 
     /** 사용자-해시태그 연결 고유 식별자 */
     @Id

--- a/src/main/java/com/pickteam/domain/videochat/VideoChannel.java
+++ b/src/main/java/com/pickteam/domain/videochat/VideoChannel.java
@@ -1,6 +1,7 @@
 package com.pickteam.domain.videochat;
 
 import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
 import com.pickteam.domain.common.BaseTimeEntity;
 import com.pickteam.domain.workspace.Workspace;
 import jakarta.persistence.*;
@@ -17,7 +18,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class VideoChannel extends BaseSoftDeleteByAnnotation {
+public class VideoChannel extends BaseSoftDeleteSupportEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/pickteam/domain/videochat/VideoMember.java
+++ b/src/main/java/com/pickteam/domain/videochat/VideoMember.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class VideoMember extends BaseSoftDeleteByAnnotation {
+public class VideoMember extends BaseSoftDeleteSupportEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/pickteam/domain/workspace/Blacklist.java
+++ b/src/main/java/com/pickteam/domain/workspace/Blacklist.java
@@ -1,6 +1,7 @@
 package com.pickteam.domain.workspace;
 
 import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
 import com.pickteam.domain.user.Account;
 import jakarta.persistence.*;
 import lombok.*;
@@ -11,7 +12,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Blacklist extends BaseSoftDeleteByAnnotation {
+public class Blacklist extends BaseSoftDeleteSupportEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/pickteam/domain/workspace/WorkspaceMember.java
+++ b/src/main/java/com/pickteam/domain/workspace/WorkspaceMember.java
@@ -1,6 +1,7 @@
 package com.pickteam.domain.workspace;
 
 import com.pickteam.domain.common.BaseSoftDeleteByAnnotation;
+import com.pickteam.domain.common.BaseSoftDeleteSupportEntity;
 import com.pickteam.domain.user.Account;
 import jakarta.persistence.*;
 import lombok.*;
@@ -14,7 +15,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class WorkspaceMember extends BaseSoftDeleteByAnnotation {
+public class WorkspaceMember extends BaseSoftDeleteSupportEntity {
     //유저가 탈퇴하거나 추방되어도 관련 정보가 삭제되면 안된다. soft-delete 처리한다.
 
     @Id

--- a/src/test/java/com/pickteam/PickTeamApplicationTests.java
+++ b/src/test/java/com/pickteam/PickTeamApplicationTests.java
@@ -7,6 +7,8 @@ import com.pickteam.dto.VideoChannelDTO;
 import com.pickteam.exception.VideoConferenceException;
 import com.pickteam.repository.VideoChannelRepository;
 import com.pickteam.repository.VideoMemberRepository;
+import com.pickteam.repository.user.AccountRepository;
+import com.pickteam.repository.workspace.WorkspaceRepository;
 import com.pickteam.service.VideoConferenceService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
soft delete 정책 변경에 따른 상속 변경
BaseSoftDeleteByAnnotation -> BaseSoftDeleteSupportEntity
어노테이션 때문에 is_deleted 컬럼이 이중으로 인식되는 이슈 수정 (어노테이션이 붙어있지 않은 수동구현 클래스로 상속 변경)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **리팩터링**
  * 여러 엔티티에서 상속받는 기본 클래스를 변경하여 소프트 삭제 관련 동작을 개선하였습니다.

* **테스트**
  * 테스트 코드에 추가적인 리포지토리 의존성을 주입하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->