### PR TITLE
Announcement 공지사항 적용, Post 페이징 기본값 20 -> 5 수정

### DIFF
--- a/src/main/java/com/pickteam/controller/board/CommentController.java
+++ b/src/main/java/com/pickteam/controller/board/CommentController.java
@@ -38,7 +38,7 @@ public class CommentController {
     public ResponseEntity<Page<CommentResponseDto>> getComments(
             @PathVariable Long postId,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size) {
+            @RequestParam(defaultValue = "5") int size) {
 
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").ascending());
         Page<CommentResponseDto> comments = commentService.getComments(postId, pageable);

--- a/src/main/java/com/pickteam/controller/board/CommentController.java
+++ b/src/main/java/com/pickteam/controller/board/CommentController.java
@@ -40,6 +40,14 @@ public class CommentController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "5") int size) {
 
+                // 페이지네이션 매개변수 검증
+                if (page < 0) {
+                    throw new IllegalArgumentException("페이지 번호는 0 이상이어야 합니다.");
+                        }
+                if (size <= 0 || size > 100) {
+                    throw new IllegalArgumentException("페이지 크기는 1-100 사이여야 합니다.");
+                }
+
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").ascending());
         Page<CommentResponseDto> comments = commentService.getComments(postId, pageable);
         return ResponseEntity.ok(comments);

--- a/src/main/java/com/pickteam/controller/board/PostController.java
+++ b/src/main/java/com/pickteam/controller/board/PostController.java
@@ -24,7 +24,7 @@ public class PostController {
     public ResponseEntity<Page<PostResponseDto>> getPosts(
             @PathVariable Long teamId,
             @RequestParam Long boardId,
-            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+            @PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
         Page<PostResponseDto> posts = postService.getPosts(boardId, pageable);
         return ResponseEntity.ok(posts);

--- a/src/main/java/com/pickteam/dto/announcement/AnnouncementPageResponse.java
+++ b/src/main/java/com/pickteam/dto/announcement/AnnouncementPageResponse.java
@@ -1,0 +1,49 @@
+package com.pickteam.dto.announcement;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+/**
+ * 공지사항 페이징 응답 DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AnnouncementPageResponse {
+
+    private List<AnnouncementResponse> announcements; // 공지사항 목록
+    private int currentPage;                          // 현재 페이지 번호 (0부터 시작)
+    private int totalPages;                           // 전체 페이지 수
+    private long totalElements;                       // 전체 게시물 수
+    private int size;                                 // 페이지 크기
+    private boolean first;                            // 첫 번째 페이지 여부
+    private boolean last;                             // 마지막 페이지 여부
+    private boolean hasNext;                          // 다음 페이지 존재 여부
+    private boolean hasPrevious;                      // 이전 페이지 존재 여부
+
+    /**
+     * Page 객체로부터 AnnouncementPageResponse 생성
+     *
+     * @param page Page<Announcement> 객체
+     * @return AnnouncementPageResponse
+     */
+    public static AnnouncementPageResponse from(Page<AnnouncementResponse> page) {
+        return AnnouncementPageResponse.builder()
+                .announcements(page.getContent())
+                .currentPage(page.getNumber())
+                .totalPages(page.getTotalPages())
+                .totalElements(page.getTotalElements())
+                .size(page.getSize())
+                .first(page.isFirst())
+                .last(page.isLast())
+                .hasNext(page.hasNext())
+                .hasPrevious(page.hasPrevious())
+                .build();
+    }
+}

--- a/src/main/java/com/pickteam/repository/announcement/AnnouncementRepository.java
+++ b/src/main/java/com/pickteam/repository/announcement/AnnouncementRepository.java
@@ -1,6 +1,8 @@
 package com.pickteam.repository.announcement;
 
 import com.pickteam.domain.announcement.Announcement;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -26,32 +28,6 @@ public interface AnnouncementRepository extends JpaRepository<Announcement, Long
             "JOIN FETCH a.team t " +
             "WHERE a.id = :id AND a.isDeleted = false")
     Optional<Announcement> findByIdAndIsDeletedFalse(@Param("id") Long id);
-
-    /**
-     * 워크스페이스의 삭제되지 않은 모든 공지사항 조회 (계정, 팀 정보 함께 조회) - 최신순 정렬
-     * @param workspaceId 워크스페이스 ID
-     * @return 공지사항 리스트 (최신순)
-     */
-    @Query("SELECT a FROM Announcement a " +
-            "JOIN FETCH a.account acc " +
-            "JOIN FETCH a.team t " +
-            "WHERE t.workspace.id = :workspaceId " +
-            "AND a.isDeleted = false " +
-            "ORDER BY a.createdAt DESC")
-    List<Announcement> findByWorkspaceIdAndIsDeletedFalseOrderByCreatedAtDesc(@Param("workspaceId") Long workspaceId);
-
-    /**
-     * 팀의 삭제되지 않은 모든 공지사항 조회 (계정 정보 함께 조회) - 최신순 정렬
-     * @param teamId 팀 ID
-     * @return 공지사항 리스트 (최신순)
-     */
-    @Query("SELECT a FROM Announcement a " +
-            "JOIN FETCH a.account acc " +
-            "JOIN FETCH a.team t " +
-            "WHERE a.team.id = :teamId " +
-            "AND a.isDeleted = false " +
-            "ORDER BY a.createdAt DESC")
-    List<Announcement> findByTeamIdAndIsDeletedFalseOrderByCreatedAtDesc(@Param("teamId") Long teamId);
 
     /**
      * 계정이 작성한 삭제되지 않은 공지사항 조회
@@ -121,4 +97,32 @@ public interface AnnouncementRepository extends JpaRepository<Announcement, Long
      * @return 공지사항이 존재하면 true
      */
     boolean existsByAccountIdAndIsDeletedFalse(Long accountId);
+
+    /**
+     * 워크스페이스의 삭제되지 않은 공지사항 페이징 조회 (계정, 팀 정보 함께 조회) - 최신순 정렬
+     * @param workspaceId 워크스페이스 ID
+     * @param pageable 페이징 정보
+     * @return 공지사항 Page 객체 (최신순)
+     */
+    @Query("SELECT a FROM Announcement a " +
+            "JOIN FETCH a.account acc " +
+            "JOIN FETCH a.team t " +
+            "WHERE t.workspace.id = :workspaceId " +
+            "AND a.isDeleted = false " +
+            "ORDER BY a.createdAt DESC")
+    Page<Announcement> findByWorkspaceIdAndIsDeletedFalse(@Param("workspaceId") Long workspaceId, Pageable pageable);
+
+    /**
+     * 팀의 삭제되지 않은 공지사항 페이징 조회 (계정 정보 함께 조회) - 최신순 정렬
+     * @param teamId 팀 ID
+     * @param pageable 페이징 정보
+     * @return 공지사항 Page 객체 (최신순)
+     */
+    @Query("SELECT a FROM Announcement a " +
+            "JOIN FETCH a.account acc " +
+            "JOIN FETCH a.team t " +
+            "WHERE a.team.id = :teamId " +
+            "AND a.isDeleted = false " +
+            "ORDER BY a.createdAt DESC")
+    Page<Announcement> findByTeamIdAndIsDeletedFalse(@Param("teamId") Long teamId, Pageable pageable);
 }


### PR DESCRIPTION
Announcement 공지사항 적용, Post 페이징 기본값 20 -> 5 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 공지사항 목록 조회 시 페이지네이션(페이징) 기능이 추가되어, 페이지 번호와 크기를 지정해 공지사항을 조회할 수 있습니다. 응답에는 전체 개수, 현재/전체 페이지 등 페이징 정보가 포함됩니다.

* **변경사항**
  * 게시글 및 댓글 목록의 기본 페이지 크기가 20개에서 5개로 변경되었습니다. 이제 한 페이지에 최대 5개의 게시글 또는 댓글이 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->