### PR TITLE
Workspace profile

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,11 @@
 # GitHub Copilot Custom Instructions
+
+## system role
+- 당신은 GitHub에서 일하고 있는 소프트웨어 엔지니어입니다.
+- 당신은 PickTeam 프로젝트의 일원으로, 이 프로젝트에 대한 깊은 이해를 가지고 있습니다.
+- 당신은 문제나 오류를 하나 해결할 때마다 추가 보너스를 받습니다.
+- 병원에서 아픈 어머니를 모시고 있으므로 병원비를 내기 위해 모든 코드를 샅샅히 살펴보며 작은 오류도 놓치지 않고 수정하려 합니다.
+
 ## General Guidelines
 - **All answers and code comments must be written in Korean.**
 - **지금부터 작성되는 모든 지침을 한국어로 작성됩니다.**

--- a/src/main/java/com/pickteam/config/DataInitializer.java
+++ b/src/main/java/com/pickteam/config/DataInitializer.java
@@ -9,6 +9,7 @@ import com.pickteam.domain.kanban.Kanban;
 import com.pickteam.domain.kanban.KanbanList;
 import com.pickteam.domain.kanban.KanbanTask;
 import com.pickteam.domain.kanban.KanbanTaskMember;
+import com.pickteam.domain.board.Board;
 import com.pickteam.repository.user.AccountRepository;
 import com.pickteam.repository.workspace.WorkspaceRepository;
 import com.pickteam.repository.workspace.WorkspaceMemberRepository;
@@ -18,12 +19,15 @@ import com.pickteam.repository.kanban.KanbanRepository;
 import com.pickteam.repository.kanban.KanbanListRepository;
 import com.pickteam.repository.kanban.KanbanTaskRepository;
 import com.pickteam.repository.kanban.KanbanTaskMemberRepository;
+import com.pickteam.repository.board.BoardRepository;
 import com.pickteam.domain.enums.UserRole;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -38,6 +42,7 @@ public class DataInitializer implements CommandLineRunner {
     private final KanbanListRepository kanbanListRepository;
     private final KanbanTaskRepository kanbanTaskRepository;
     private final KanbanTaskMemberRepository kanbanTaskMemberRepository;
+    private final BoardRepository boardRepository;
     private final PasswordEncoder passwordEncoder;
     
     @Override
@@ -133,6 +138,12 @@ public class DataInitializer implements CommandLineRunner {
                 .build();
         frontendTeam = teamRepository.save(frontendTeam);
         
+        // 프론트엔드팀 게시판 생성
+        Board frontendBoard = Board.builder()
+                .team(frontendTeam)
+                .build();
+        boardRepository.save(frontendBoard);
+        
         // 프론트엔드팀 멤버십 생성
         createTeamMembership(frontendTeam, user1, TeamMember.TeamRole.LEADER);
         createTeamMembership(frontendTeam, user3, TeamMember.TeamRole.MEMBER);
@@ -146,6 +157,12 @@ public class DataInitializer implements CommandLineRunner {
                 .workspace(workspace)
                 .build();
         backendTeam = teamRepository.save(backendTeam);
+        
+        // 백엔드팀 게시판 생성
+        Board backendBoard = Board.builder()
+                .team(backendTeam)
+                .build();
+        boardRepository.save(backendBoard);
         
         // 백엔드팀 멤버십 생성
         createTeamMembership(backendTeam, user2, TeamMember.TeamRole.LEADER);
@@ -274,4 +291,4 @@ public class DataInitializer implements CommandLineRunner {
     private String generateRandomCode() {
         return java.util.UUID.randomUUID().toString().substring(0, 8).toUpperCase();
     }
-} 
+}

--- a/src/main/java/com/pickteam/config/FileUploadConfig.java
+++ b/src/main/java/com/pickteam/config/FileUploadConfig.java
@@ -3,6 +3,8 @@ package com.pickteam.config;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import jakarta.annotation.PostConstruct;
 import java.io.IOException;
@@ -11,7 +13,7 @@ import java.nio.file.Paths;
 
 @Configuration
 @Slf4j
-public class FileUploadConfig {
+public class FileUploadConfig implements WebMvcConfigurer {
 
     @Value("${app.upload.dir}")
     private String uploadDir;
@@ -24,5 +26,12 @@ public class FileUploadConfig {
         } catch (IOException e) {
             log.error("업로드 디렉토리 생성 실패: {}", uploadDir, e);
         }
+    }
+    
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations("file:" + uploadDir + "/")
+                .setCachePeriod(3600);
     }
 }

--- a/src/main/java/com/pickteam/config/SecurityConfig.java
+++ b/src/main/java/com/pickteam/config/SecurityConfig.java
@@ -76,7 +76,10 @@ public class SecurityConfig {
                         // 프로필 이미지는 공개 접근 허용
                         .requestMatchers("/profile-images/**").permitAll()
 
-                        // 업로드 파일 직접 접근 차단 (보안 강화)
+                        // 워크스페이스 아이콘은 공개 접근 허용
+                        .requestMatchers("/uploads/workspace-icons/**").permitAll()
+
+                        // 기타 업로드 파일 직접 접근 차단 (보안 강화)
                         .requestMatchers("/uploads/**").denyAll()
 
                         // 파일 다운로드는 컨트롤러를 통해서만 허용 (인증 필요)

--- a/src/main/java/com/pickteam/controller/WorkspaceController.java
+++ b/src/main/java/com/pickteam/controller/WorkspaceController.java
@@ -8,9 +8,11 @@ import com.pickteam.service.WorkspaceService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import jakarta.validation.Valid;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.HashMap;
 import java.util.List;
@@ -101,7 +103,23 @@ public class WorkspaceController {
     }
     
     /**
-     * 워크스페이스 설정 업데이트
+     * 워크스페이스 아이콘 업로드
+     */
+    @PostMapping(value = "/{workspaceId}/icon", consumes = {"multipart/form-data"})
+    public ResponseEntity<ApiResponse<Map<String, String>>> uploadWorkspaceIcon(
+            @PathVariable Long workspaceId,
+            @RequestParam("file") MultipartFile file) {
+        Long userId = getCurrentUserId();
+        String iconUrl = workspaceService.uploadWorkspaceIcon(workspaceId, userId, file);
+        
+        Map<String, String> response = new HashMap<>();
+        response.put("iconUrl", iconUrl);
+        
+        return ResponseEntity.ok(ApiResponse.success("워크스페이스 아이콘 업로드 성공", response));
+    }
+
+    /**
+     * 워크스페이스 정보 업데이트
      */
     @PutMapping("/{workspaceId}")
     public ResponseEntity<ApiResponse<WorkspaceResponse>> updateWorkspace(
@@ -184,4 +202,4 @@ public class WorkspaceController {
         workspaceService.deleteWorkspace(workspaceId, userId);
         return ResponseEntity.ok(ApiResponse.success("워크스페이스 삭제 성공", null));
     }
-} 
+}

--- a/src/main/java/com/pickteam/domain/workspace/Workspace.java
+++ b/src/main/java/com/pickteam/domain/workspace/Workspace.java
@@ -28,7 +28,7 @@ public class Workspace extends BaseSoftDeleteSupportEntity {
     @Column(unique = true)
     private String url;
     
-    @Column(name = "icon_url")
+    @Column(name = "icon_url", length = 500)
     private String iconUrl;
 
     @ManyToOne(optional = false)

--- a/src/main/java/com/pickteam/dto/kanban/KanbanListUpdateRequest.java
+++ b/src/main/java/com/pickteam/dto/kanban/KanbanListUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.pickteam.dto.kanban;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class KanbanListUpdateRequest {
+
+    private String kanbanListName;
+    private Integer order;
+} 

--- a/src/main/java/com/pickteam/dto/team/TeamResponse.java
+++ b/src/main/java/com/pickteam/dto/team/TeamResponse.java
@@ -25,6 +25,7 @@ public class TeamResponse {
     private UserSummaryResponse leader;
     private int memberCount;
     private List<TeamMemberResponse> members;
+    private Long boardId; // 게시판 ID 추가
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 } 

--- a/src/main/java/com/pickteam/dto/workspace/WorkspaceCreateRequest.java
+++ b/src/main/java/com/pickteam/dto/workspace/WorkspaceCreateRequest.java
@@ -10,7 +10,7 @@ public class WorkspaceCreateRequest {
     @Size(min = 1, max = 50, message = "워크스페이스 이름은 1자 이상 50자 이하여야 합니다")
     private String name;
     
-    @Size(max = 10, message = "아이콘은 10자 이하여야 합니다")
+    @Size(max = 500, message = "아이콘 URL은 500자 이하여야 합니다")
     private String iconUrl;
     
     @Size(min = 4, max = 100, message = "비밀번호는 4자 이상 100자 이하여야 합니다")

--- a/src/main/java/com/pickteam/dto/workspace/WorkspaceUpdateRequest.java
+++ b/src/main/java/com/pickteam/dto/workspace/WorkspaceUpdateRequest.java
@@ -10,7 +10,7 @@ public class WorkspaceUpdateRequest {
     @Size(min = 1, max = 50, message = "워크스페이스 이름은 1자 이상 50자 이하여야 합니다")
     private String name;
     
-    @Size(max = 10, message = "아이콘은 10자 이하여야 합니다")
+    @Size(max = 500, message = "아이콘 URL은 500자 이하여야 합니다")
     private String iconUrl;
     
     @Size(min = 4, max = 100, message = "비밀번호는 4자 이상 100자 이하여야 합니다")

--- a/src/main/java/com/pickteam/repository/board/BoardRepository.java
+++ b/src/main/java/com/pickteam/repository/board/BoardRepository.java
@@ -1,6 +1,7 @@
 package com.pickteam.repository.board;
 
 import com.pickteam.domain.board.Board;
+import com.pickteam.domain.team.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -34,4 +35,12 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
      */
     @Query("SELECT b FROM Board b JOIN FETCH b.team WHERE b.id = :boardId AND b.isDeleted = false")
     Optional<Board> findByIdWithTeamAndIsDeletedFalse(@Param("boardId") Long boardId);
+    
+    /**
+     * 특정 팀의 활성 게시판 조회
+     *
+     * @param team 팀 엔티티
+     * @return 해당 팀의 삭제되지 않은 게시판 (Optional)
+     */
+    Optional<Board> findByTeamAndIsDeletedFalse(Team team);
 }

--- a/src/main/java/com/pickteam/service/board/PostService.java
+++ b/src/main/java/com/pickteam/service/board/PostService.java
@@ -49,7 +49,7 @@ public class PostService {
         Account account = accountRepository.findById(accountId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. accountId: " + accountId));
 
-        Board board = boardRepository.findById(dto.getBoardId())
+        Board board = boardRepository.findByIdAndIsDeletedFalse(dto.getBoardId())
                 .orElseThrow(() -> new IllegalArgumentException("게시판을 찾을 수 없습니다. boardId: " + dto.getBoardId()));
 
         Integer nextPostNo = postRepository.findMaxPostNoByBoardIdAndIsDeletedFalse(dto.getBoardId()) + 1;

--- a/src/main/java/com/pickteam/service/user/AuthServiceImpl.java
+++ b/src/main/java/com/pickteam/service/user/AuthServiceImpl.java
@@ -191,6 +191,7 @@ public class AuthServiceImpl implements AuthService {
      * @throws UserNotFoundException 사용자가 존재하지 않을 시
      */
     @Override
+    @Transactional
     public JwtAuthenticationResponse refreshToken(RefreshTokenRequest request) {
         log.info("토큰 갱신 시도");
 
@@ -297,6 +298,7 @@ public class AuthServiceImpl implements AuthService {
      * @param token   저장할 토큰 문자열
      * @return 저장된 RefreshToken 엔티티
      */
+    @Transactional
     private RefreshToken createAndSaveRefreshToken(Account account, String token) {
         refreshTokenRepository.deleteByAccount(account);
         LocalDateTime now = LocalDateTime.now();


### PR DESCRIPTION
사이드바 이미지 업로드 기능 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 워크스페이스 아이콘 업로드 API가 추가되어, 사용자가 워크스페이스 아이콘 이미지를 업로드 및 변경할 수 있습니다.
  * 팀 생성 시 자동으로 보드가 생성되고, 팀 정보 응답에 boardId가 포함됩니다.
  * 칸반 리스트 업데이트를 위한 DTO가 추가되었습니다.

* **개선 사항**
  * 워크스페이스 아이콘 URL의 최대 길이가 500자로 확장되었습니다.
  * 워크스페이스 아이콘 업로드 경로(/uploads/workspace-icons/**)에 대한 공개 접근이 허용되었습니다.
  * 파일 업로드 경로가 정적으로 제공되어 업로드된 파일을 웹에서 접근할 수 있습니다.

* **버그 수정**
  * 삭제된 보드에는 게시글을 생성할 수 없도록 보드 조회 로직이 개선되었습니다.

* **기타**
  * 인증 서비스의 토큰 관련 메서드에 트랜잭션 처리가 추가되었습니다.
  * 테스트 데이터 초기화 시 팀에 보드가 생성됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->