### PR TITLE
화상회의 버그 수정

### DIFF
--- a/src/main/java/com/pickteam/repository/VideoChannelRepository.java
+++ b/src/main/java/com/pickteam/repository/VideoChannelRepository.java
@@ -11,5 +11,5 @@ public interface VideoChannelRepository extends JpaRepository<VideoChannel, Long
     @Query("select v from VideoChannel v where v.workspace.id=?1 and v.isDeleted=false")
     List<VideoChannel> selectChannelsByWorkSpaceId(Long workspaceId);
 
-    VideoChannel findByName(String name);
+    List<VideoChannel> findByName(String name);
 }

--- a/src/main/java/com/pickteam/service/VideoConferenceServiceImpl.java
+++ b/src/main/java/com/pickteam/service/VideoConferenceServiceImpl.java
@@ -82,9 +82,15 @@ public class VideoConferenceServiceImpl implements VideoConferenceService {
     @Transactional
     @Override
     public VideoChannelDTO insertVideoChannel(Long workspaceId, String videoChannelName) throws VideoConferenceException {
-        VideoChannel vc = videoChannelRepository.findByName(videoChannelName);
-        if(vc != null && !vc.getIsDeleted()) {
-            throw new VideoConferenceException(VideoConferenceErrorCode.DUPLICATE_CHANNEL_NAME);
+        //같은 이름의 채널을 만들고 삭제 후 또 만들고 삭제 시 채널 이름으로 조회시 결과가 여러개 나올수있음
+        List<VideoChannel> vc = videoChannelRepository.findByName(videoChannelName);
+
+        if(vc != null && !vc.isEmpty()) {
+            for (VideoChannel vc1 : vc) {
+                if(vc1.isActive()){
+                    throw new VideoConferenceException(VideoConferenceErrorCode.DUPLICATE_CHANNEL_NAME);
+                }
+            }
         }
         Workspace workspace = Workspace.builder().id(workspaceId).build();
         VideoChannel videochannel = VideoChannel.builder().name(videoChannelName).workspace(workspace).build();


### PR DESCRIPTION
어떤 이름의 팀을 생성하고 지운 후 다시 그 이름으로 생성하고 지우면 그 이름으로는 생성되지 않는 버그 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 삭제된 채널이 있을 때 동일한 이름의 비디오 채널을 생성할 수 없던 문제를 해결하였습니다. 이제 삭제된 채널과 이름이 같더라도 정상적으로 새 채널을 생성할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->